### PR TITLE
Fix card_power_outlet

### DIFF
--- a/config/minimalist-templates/button_card_templates.yaml
+++ b/config/minimalist-templates/button_card_templates.yaml
@@ -502,15 +502,24 @@ card_light_slider_horizontal:
             box-shadow: none;
           }
 card_power_outlet:
-  template: 
+  template:
+    - icon_info_bg
     - yellow
-    - icon_info_bg 
+    - ulm_language_variables
+  variables:
+    ulm_card_power_outlet_consumption_sensor:
   label: |-
-    [[[ 
-      if (entity.state =='on') && (variables.ulm_card_power_outlet_consumption_sensor != '' {
-        return entity.label + ' ' + variables.ulm_card_power_outlet_consumption_sensor + 'W';
+    [[[
+      if (entity.state === "on" && variables.ulm_card_power_outlet_consumption_sensor !== null) {
+        return variables.ulm_on + " • " + states[variables.ulm_card_power_outlet_consumption_sensor].state + "W";
+      } else if (entity.state === "on") {
+        return variables.ulm_on;
+      } else if (entity.state === "off") {
+        return variables.ulm_off;
+      } else if (entity.state === "unavailable") {
+        return variables.ulm_unavailable;
       } else {
-        return entity.label;
+        return entity.state;
       }
     ]]]
 card_binary_sensor:


### PR DESCRIPTION
Bug https://github.com/UI-Lovelace-Minimalist/UI/issues/14

Consumption sensor is now optional to specify in the card configuration.
```
- type: 'custom:button-card'
  template: card_power_outlet
  entity: switch.power_outlet_livingroom
  name: Switch 1
```
![Switch_OFF](https://user-images.githubusercontent.com/12456858/140466627-d547063d-4161-40c7-a597-6c4350e5cda1.png)
![Switch_ON](https://user-images.githubusercontent.com/12456858/140466631-e43c4bba-0f9d-469d-add0-2121daee2de1.png)
![Switch_ON_Power_Consumption](https://user-images.githubusercontent.com/12456858/140466633-75021178-0e5b-40a5-a06e-8efa40fa4151.png)

