### PR TITLE
Fix "chip_icon_only", "chip_icon_state" and "chip_icon_double_state"

### DIFF
--- a/config/minimalist-templates/button_card_templates.yaml
+++ b/config/minimalist-templates/button_card_templates.yaml
@@ -60,7 +60,7 @@ chip_icon_state:
       if (variables.ulm_chip_icon_state_icon){
         var icon = variables.ulm_chip_icon_state_icon;
       } 
-      var state = 'default';
+      var state = '';
       if (states[variables.ulm_chip_icon_state_entity].state){
         var state = states[variables.ulm_chip_icon_state_entity].state;
       } 
@@ -68,23 +68,25 @@ chip_icon_state:
     ]]]
 chip_icon_double_state:
   template: chips
-  variables:
-    icon: "❔"
   triggers_update:
     - "[[[ variables.ulm_chip_icon_state_entity_1 ]]]"
     - "[[[ variables.ulm_chip_icon_state_entity_2 ]]]"
-  show_icon: true
-  show_label: true
-  icon: "[[[ return variables.ulm_chip_icon_double_state_icon ? variables.ulm_chip_icon_double_state_icon : variables.icon ]]]"
-  label: "[[[ return variables.ulm_chip_icon_double_state_entity_1 ? states[variables.ulm_chip_icon_double_state_entity_1].state + ' • ' + states[variables.ulm_chip_icon_double_state_entity_2].state : '' ]]]"
-  styles:
-    label:
-      - justify-self: center
-      - padding: 0px 6px
-      - font-weight: bold
-      - font-size: 14px
-    grid:
-      - grid-template-areas: '"i l"'
+  label: |
+    [[[
+      var icon = '❔';
+      if (variables.ulm_chip_icon_double_state_icon){
+        var icon = variables.ulm_chip_icon_double_state_icon;
+      } 
+      var state1 = '';
+      if (states[variables.ulm_chip_icon_double_state_entity_1].state){
+        var state = states[variables.ulm_chip_icon_double_state_entity_1].state;
+      } 
+      var state2 = '';
+      if (states[variables.ulm_chip_icon_double_state_entity_2].state){
+        var state = states[variables.ulm_chip_icon_double_state_entity_2].state;
+      } 
+      return icon + ' ' + state1 + ' • ' + state2;
+    ]]]
 chip_back:
   template: chips
   tap_action:

--- a/config/minimalist-templates/button_card_templates.yaml
+++ b/config/minimalist-templates/button_card_templates.yaml
@@ -41,31 +41,31 @@ chip_temperature:
     ]]]
 chip_icon_only:
   template: chips
-  variables:
-    icon: '❔'
-  show_icon: true
   icon: "[[[ return variables.ulm_chip_icon_only ? variables.ulm_chip_icon_only : variables.icon ]]]"
-  styles:
-    grid:
-      - grid-template-areas: '"i"'
+  label: |
+    [[[
+      var icon = '❔';
+      if (variables.ulm_chip_icon_only){
+        var icon = variables.ulm_chip_icon_only;
+      } 
+      return icon;
+    ]]]
 chip_icon_state:
   template: chips
-  variables:
-    icon: "❔"
   triggers_update:
     - "[[[ variables.ulm_chip_icon_state_entity ]]]"
-  show_icon: true
-  show_label: true
-  icon: "[[[ return variables.ulm_chip_icon_state_icon ? variables.ulm_chip_icon_state_icon : variables.icon ]]]"
-  label: "[[[ return variables.ulm_chip_icon_state_entity ? states[variables.ulm_chip_icon_state_entity].state : '' ]]]"
-  styles:
-    label:
-      - justify-self: center
-      - padding: 0px 6px
-      - font-weight: bold
-      - font-size: 14px
-    grid:
-      - grid-template-areas: '"i l"'
+  label: |
+    [[[
+      var icon = '❔';
+      if (variables.ulm_chip_icon_state_icon){
+        var icon = variables.ulm_chip_icon_state_icon;
+      } 
+      var state = 'default';
+      if (states[variables.ulm_chip_icon_state_entity].state){
+        var state = states[variables.ulm_chip_icon_state_entity].state;
+      } 
+      return icon + ' ' + state;
+    ]]]
 chip_icon_double_state:
   template: chips
   variables:

--- a/config/minimalist-templates/button_card_templates.yaml
+++ b/config/minimalist-templates/button_card_templates.yaml
@@ -41,7 +41,6 @@ chip_temperature:
     ]]]
 chip_icon_only:
   template: chips
-  icon: "[[[ return variables.ulm_chip_icon_only ? variables.ulm_chip_icon_only : variables.icon ]]]"
   label: |
     [[[
       var icon = '❔';
@@ -69,8 +68,8 @@ chip_icon_state:
 chip_icon_double_state:
   template: chips
   triggers_update:
-    - "[[[ variables.ulm_chip_icon_state_entity_1 ]]]"
-    - "[[[ variables.ulm_chip_icon_state_entity_2 ]]]"
+    - "[[[ variables.ulm_chip_icon_double_state_entity_1 ]]]"
+    - "[[[ variables.ulm_chip_icon_double_state_entity_2 ]]]"
   label: |
     [[[
       var icon = '❔';
@@ -79,11 +78,11 @@ chip_icon_double_state:
       } 
       var state1 = '';
       if (states[variables.ulm_chip_icon_double_state_entity_1].state){
-        var state = states[variables.ulm_chip_icon_double_state_entity_1].state;
+        var state1 = states[variables.ulm_chip_icon_double_state_entity_1].state;
       } 
       var state2 = '';
       if (states[variables.ulm_chip_icon_double_state_entity_2].state){
-        var state = states[variables.ulm_chip_icon_double_state_entity_2].state;
+        var state2 = states[variables.ulm_chip_icon_double_state_entity_2].state;
       } 
       return icon + ' ' + state1 + ' • ' + state2;
     ]]]


### PR DESCRIPTION
Since the basic chip template does not have an icon section, no dependent chip cards can use it. Due to this MR "`chip_icon_only`", "`chip_icon_state`" and "`chip_icon_double_state`" use variables that are only mapped via the template section.