### PR TITLE
Add rounding and german translation to schumijo car card

### DIFF
--- a/custom_cards/custom_card_schumijo_car/custom_card_schumijo_car.yaml
+++ b/custom_cards/custom_card_schumijo_car/custom_card_schumijo_car.yaml
@@ -140,13 +140,13 @@ custom_card_schumijo_car:
             card:
               type: "custom:button-card"
               template: "widget_icon_state"
-              entity: "[[[ return variables.ulm_card_schumijo_car_energy_level ]]]"
+              entity: "[[[ return parseFloat(states[variables.ulm_card_schumijo_car_energy_level].state).toFixed(0) ]]]"
               name: "[[[ return states[variables.ulm_card_schumijo_car_energy_level].attributes.unit_of_measurement + ' ' + variables.ulm_custom_card_schumijo_car_energy_level\
                 \ ]]]"
           item2:
             card:
               type: "custom:button-card"
               template: "widget_icon_state"
-              entity: "[[[ return variables.ulm_card_schumijo_car_range ]]]"
+              entity: "[[[ return parseFloat(states[variables.ulm_card_schumijo_car_range].state).toFixed(0) ]]]"
               name: "[[[ return states[variables.ulm_card_schumijo_car_range].attributes.unit_of_measurement + ' ' + variables.ulm_custom_card_schumijo_car_range\
                 \ ]]]"

--- a/custom_cards/custom_card_schumijo_car/languages/DE.yaml
+++ b/custom_cards/custom_card_schumijo_car/languages/DE.yaml
@@ -1,0 +1,6 @@
+---
+ulm_custom_card_schumijo_car_language_variables:
+  variables:
+    ulm_custom_card_schumijo_car_default_name: "Mein Auto"
+    ulm_custom_card_schumijo_car_range: "Reichweite"
+    ulm_custom_card_schumijo_car_energy_level: "Tankinhalt"


### PR DESCRIPTION
Hello @schumijo , I would like to suggest removing the decimal places for the energy level and range on your custom_card_schumijo_car. 
I think the card is great and I use it myself. However, my Toyota integration provides up to 6 decimal places for the fuel level. This is, in my opinion, nice to have but unnecessary in the UI. There, a glance at the value without decimal places is actually enough for me to inform myself briefly.

BTW: I have also added a German translation :-)