### PR TITLE
Introduce padding with card-mod-view-yaml

### DIFF
--- a/config/themes/minimalist-desktop/minimalist-desktop.yaml
+++ b/config/themes/minimalist-desktop/minimalist-desktop.yaml
@@ -9,6 +9,14 @@ minimalist-desktop:
   info-color: "var(--google-blue)"
   divider-color: "rgba(var(--color-theme),.12)"
   accent-color: "var(--google-yellow)"
+  card-mod-theme: "minimalist-desktop"
+  card-mod-view-yaml: |
+    "*:first-child$": |
+      #columns .column > * {
+        padding-left: 5px;
+        padding-right: 5px;
+        padding-bottom: 5px;
+      }
   modes:
     light:
       # text

--- a/config/themes/minimalist-mobile/minimalist-mobile.yaml
+++ b/config/themes/minimalist-mobile/minimalist-mobile.yaml
@@ -14,6 +14,13 @@ minimalist-mobile:
     app-toolbar {
       display: none;
     }
+  card-mod-view-yaml: |
+    "*:first-child$": |
+      #columns .column > * {
+        padding-left: 5px;
+        padding-right: 5px;
+        padding-bottom: 5px;
+      }
   modes:
     light:
       # text


### PR DESCRIPTION
Introduce automatic padding with the help of card-mod-view-yaml like suggestet from @aFFekopp

```yaml
  card-mod-view-yaml: |
    "*:first-child$": |
      #columns .column > * {
        padding-left: 5px;
        padding-right: 5px;
        padding-bottom: 5px;
      } 
```