### PR TITLE
Fix guest presence counter

### DIFF
--- a/config/minimalist-templates/button_card_templates.yaml
+++ b/config/minimalist-templates/button_card_templates.yaml
@@ -135,8 +135,7 @@ chip_presence_detection:
   triggers_update: "all"
   label: |
     [[[
-      var guests = variables.ulm_chip_presence_counter_guests != "" ? true : false
-      if (guests){
+      if (!!variables.ulm_chip_presence_counter_guests) {
         return "🏠 " +  states[variables.ulm_chip_presence_counter_residents].state + " / " + states[variables.ulm_chip_presence_counter_guests].state;
       } else {
         return "🏠 " +  states[variables.ulm_chip_presence_counter_residents].state;


### PR DESCRIPTION
This fixes the guest presence counter by making the field optional.

Before you had to set `ulm_chip_presence_counter_guests = ""` to make it optional what seems counter intuitive to me.
I guess this should make it more easy to use.