### PR TITLE
Fix non colored chips on edge and chrome

### DIFF
--- a/config/minimalist-templates/button_card_templates.yaml
+++ b/config/minimalist-templates/button_card_templates.yaml
@@ -1318,7 +1318,7 @@ chips:
     label:
       - justify-self: "center"
       - padding: "0px 6px"
-      - font-weight: "bold"
+      - font-weight: 500
       - font-size: "14px"
     img_cell:
       - width: "24px"


### PR DESCRIPTION
There is a bug that causes bold emojis to be displayed only in black and white in the chromium engin:
https://bugs.chromium.org/p/chromium/issues/detail?id=1266022
This PR reduces the font-weight for chips from "bold" to 500. This will make emojis display correctly in color again on Chrome and Edge.
The thickness of the font is also reduced a bit, but still fits well in the overall look of the theme