### PR TITLE
Make card_person zones optional and more robust

### DIFF
--- a/config/minimalist-templates/button_card_templates.yaml
+++ b/config/minimalist-templates/button_card_templates.yaml
@@ -992,7 +992,7 @@ card_person:
       - color: "rgba(var(--color-theme),0.9)"
       - width: >
           [[[
-            if (variables.ulm_card_person_use_entity_picture != true){
+            if (variables.ulm_card_person_use_entity_picture !== true){
               return "20px";
             } else {
               return "42px";
@@ -1000,7 +1000,7 @@ card_person:
           ]]]
       - place-self: >
           [[[
-            if (variables.ulm_card_person_use_entity_picture != true){
+            if (variables.ulm_card_person_use_entity_picture !== true){
               return "center";
             } else {
               return "stretch stretch";
@@ -1019,7 +1019,7 @@ card_person:
         - line-height: "14px"
         - background-color: >
             [[[
-              if (states[variables.ulm_card_person_entity].state != 'home'){
+              if (states[variables.ulm_card_person_entity].state !== 'home') {
                 return "rgba(var(--color-green),1)";
               } else {
                 return "rgba(var(--color-blue),1)";
@@ -1028,12 +1028,12 @@ card_person:
   custom_fields:
     notification: >
       [[[
-        if (states[variables.ulm_card_person_entity].state != 'home'){
-          if (states[variables.ulm_card_person_entity].state == states[variables.ulm_card_person_zone1].attributes.friendly_name){
-            var icon = states[variables.ulm_card_person_zone1].attributes.icon != null ? states[variables.ulm_card_person_zone1].attributes.icon : 'mdi:help-circle'
+        if (states[variables.ulm_card_person_entity].state !== 'home') {
+          if (states[variables.ulm_card_person_entity].state === states[variables.ulm_card_person_zone1]?.attributes?.friendly_name) {
+            var icon = states[variables.ulm_card_person_zone1].attributes.icon !== null ? states[variables.ulm_card_person_zone1].attributes.icon : 'mdi:help-circle'
             return '<ha-icon icon="' + icon + '" style="width: 10px; height: 10px; color: var(--primary-background-color);"></ha-icon>';
-          } else if (states[variables.ulm_card_person_entity].state == states[variables.ulm_card_person_zone2].attributes.friendly_name){
-            var icon = states[variables.ulm_card_person_zone2].attributes.icon != null ? states[variables.ulm_card_person_zone2].attributes.icon : 'mdi:help-circle'
+          } else if (states[variables.ulm_card_person_entity].state === states[variables.ulm_card_person_zone2]?.attributes?.friendly_name) {
+            var icon = states[variables.ulm_card_person_zone2].attributes.icon !== null ? states[variables.ulm_card_person_zone2].attributes.icon : 'mdi:help-circle'
             return '<ha-icon icon="' + icon + '" style="width: 10px; height: 10px; color: var(--primary-background-color);"></ha-icon>';
           } else {
             return '<ha-icon icon="mdi:home-minus" style="width: 10px; height: 10px; color: var(--primary-background-color);"></ha-icon>';


### PR DESCRIPTION
This fixes some errors when users input wrong data into the zones.
Additionally this makes them optional as some users may not have two zones and therefore the card won't display at all when the user isn't at `home`.

I added some safe equal operations as some of the data could potentially be `""` or a boolean 😄 