### PR TITLE
Automatically detect lowercase readme.md files

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -16,5 +16,10 @@ jobs:
         uses: "actions/setup-python@v2"
         with:
           python-version: 3.8
+      - name: "⚙️ Set up Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
       - name: "\U0001F680 Run pre-commit"
         uses: "pre-commit/action@v2.0.3"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,4 +23,9 @@ repos:
     hooks:
       - id: "yamlfmt"
         args: ["--mapping", "2", "--sequence", "4", "--offset", "2", "--preserve-quotes"]
-        exclude: ".github/release-drafter.yml"
+        exclude: ".*"
+
+  - repo: "https://github.com/mattlqx/pre-commit-search-and-replace"
+    rev: "v1.0.5"
+    hooks:
+      - id: "search-and-replace"

--- a/.pre-commit-search-and-replace.yaml
+++ b/.pre-commit-search-and-replace.yaml
@@ -1,0 +1,4 @@
+---
+- search: "readme.md"
+  insensitive: true
+  replacement: "README.md"

--- a/.pre-commit-search-and-replace.yaml
+++ b/.pre-commit-search-and-replace.yaml
@@ -2,3 +2,9 @@
 - search: "readme.md"
   insensitive: true
   replacement: "README.md"
+- search: "changelog.md"
+  insensitive: true
+  replacement: "CHANGELOG.md"
+- search: "license.md"
+  insensitive: true
+  replacement: "LICENSE.md"


### PR DESCRIPTION
Hello, I have reworked our pre-commit hook a bit so that it automatically detects and reports readme files written in lowercase.
If you execute the pre-commit hook locally, the detected files are also automatically fixed and converted to uppercase. However, it is required that you have ruby installed for this.

We could also have other strings recognised and rewritten automatically using regex. If you can think of something useful, please let me know.