### PR TITLE
Fix battery_card icon color when state is unavailable

### DIFF
--- a/config/minimalist-templates/button_card_templates.yaml
+++ b/config/minimalist-templates/button_card_templates.yaml
@@ -930,25 +930,23 @@ card_battery:
     ]]]
   styles:
     icon:
-      - color: >
+      - color: |
           [[[
-              // --color-theme as default
-              var color = 'rgba(var(--color-theme),0.9)';
-              var battery_level = variables.ulm_card_battery_attribute !== null
-              ? states[entity.entity_id].attributes[variables.ulm_card_battery_attribute]
-              : states[entity.entity_id].state;
+            var color = "rgba(var(--color-theme),0.9)";
+            var battery_level = variables.ulm_card_battery_attribute !== null
+                                  ? states[entity.entity_id].attributes[variables.ulm_card_battery_attribute]
+                                  : states[entity.entity_id].state;
 
-              // color based on battery_level
-              if(variables.ulm_card_battery_battery_level_danger !== null
-              || variables.ulm_card_battery_battery_level_warning !== null ) {
-                color = variables.ulm_card_battery_color_battery_level_ok ;
-                if(variables.ulm_card_battery_battery_level_warning>=battery_level) {
-                  color = variables.ulm_card_battery_color_battery_level_warning
-                }
-                if(variables.ulm_card_battery_battery_level_danger>=battery_level) {
-                  color = variables.ulm_card_battery_color_battery_level_danger
-                }
+            // color based on battery_level
+            if (battery_level !== "unavailable" && (variables.ulm_card_battery_battery_level_danger !== null || variables.ulm_card_battery_battery_level_warning !== null)) {
+              if (battery_level <= variables.ulm_card_battery_battery_level_danger) {
+                color = variables.ulm_card_battery_color_battery_level_danger;
+              } else if (battery_level <= variables.ulm_card_battery_battery_level_warning) {
+                color = variables.ulm_card_battery_color_battery_level_warning;
+              } else {
+                color = variables.ulm_card_battery_color_battery_level_ok;
               }
+            }
             return color;
           ]]]
     label:


### PR DESCRIPTION
The battery card showed the icon as green when the state is unavailable.  I think it would be more appropriate to show the default color in such case.

Before:
![image](https://user-images.githubusercontent.com/12456858/147405332-ff054608-0c08-496d-a4a0-c8dc43dff3f7.png)

After (Light Mode):
![image](https://user-images.githubusercontent.com/12456858/147405335-70636b86-6b01-437f-a21c-9223afbc0ade.png)

After (Dark Mode):
![image](https://user-images.githubusercontent.com/12456858/147405353-0f2f2b7e-b82e-49c8-9ec5-22df149fe553.png)
