### PR TITLE
Fix custom_card_saxel blue style card

### DIFF
--- a/custom_cards/custom_card_saxel_fan/custom_card_saxel_fan.yaml
+++ b/custom_cards/custom_card_saxel_fan/custom_card_saxel_fan.yaml
@@ -153,7 +153,7 @@ custom_card_saxel_fan_common:
 
 custom_template_saxel_blue:
   state:
-    - value: on
+    - value: "on"
       styles:
         card:
           - background-color: "rgba(61, 90, 254, 1)"


### PR DESCRIPTION
After the commit "Add pre-commit hook and modify files" my blue style custom card was not formatted properly due to this change. I think it was a simple mistake.