### PR TITLE
Fix black and white weather icons when bold

### DIFF
--- a/config/minimalist-templates/button_card_templates.yaml
+++ b/config/minimalist-templates/button_card_templates.yaml
@@ -44,7 +44,7 @@ chip_temperature:
       }
       var outside_temp = states[variables.ulm_chip_temperature_outside].state;
       var inside_temp = states[variables.ulm_chip_temperature_inside].state;
-      return "<span style='font-weight:500;'>" + icon + "</span>" + " " + convertTemperature(outside_temp) + "° / " + convertTemperature(inside_temp) + "°" ;
+      return icon + " " + convertTemperature(outside_temp) + "° / " + convertTemperature(inside_temp) + "°" ;
     ]]]
 chip_icon_only:
   template: "chips"

--- a/config/minimalist-templates/button_card_templates.yaml
+++ b/config/minimalist-templates/button_card_templates.yaml
@@ -1361,7 +1361,7 @@ chips:
     label:
       - justify-self: "center"
       - padding: "0px 6px"
-      - font-weight: bold
+      - font-weight: "bold"
       - font-size: "14px"
     img_cell:
       - width: "24px"

--- a/config/minimalist-templates/button_card_templates.yaml
+++ b/config/minimalist-templates/button_card_templates.yaml
@@ -44,7 +44,7 @@ chip_temperature:
       }
       var outside_temp = states[variables.ulm_chip_temperature_outside].state;
       var inside_temp = states[variables.ulm_chip_temperature_inside].state;
-      return icon + " " + convertTemperature(outside_temp) + "° / " + convertTemperature(inside_temp) + "°" ;
+      return "<span style='font-weight:500;'>" + icon + "</span>" + " " + convertTemperature(outside_temp) + "° / " + convertTemperature(inside_temp) + "°" ;
     ]]]
 chip_icon_only:
   template: "chips"
@@ -1361,7 +1361,7 @@ chips:
     label:
       - justify-self: "center"
       - padding: "0px 6px"
-      - font-weight: 500
+      - font-weight: bold
       - font-size: "14px"
     img_cell:
       - width: "24px"


### PR DESCRIPTION
Due to a bug in Chrome, emojis would lose colour if the font-weight was set to "bold". This change fixes this by wrapping the icon in a span and explcitly giving it a weight of 500 to preserve colour, leaving the label bold.