### PR TITLE
Add unit of measurement in chip_power_consumption when price is not showed

### DIFF
--- a/config/minimalist-templates/button_card_templates.yaml
+++ b/config/minimalist-templates/button_card_templates.yaml
@@ -153,7 +153,7 @@ chip_power_consumption:
       if (amount){
         return "⚡ " +  states[variables.ulm_chip_electric_price].state + variables.ulm_currency;
       } else {
-        return "⚡ " +  states[variables.ulm_chip_electric_consumption].state;
+        return "⚡ " +  states[variables.ulm_chip_electric_consumption].state + states[variables.ulm_chip_electric_consumption].attributes.unit_of_measurement;
       }
     ]]]
 chip_navigate:


### PR DESCRIPTION
When the variable `ulm_chip_electric_price` is not set there isn't any information about the number displayed. Added unit of measurement of the sensor from `ulm_chip_electric_consumption`. 