### PR TITLE
HACS: Fix Jinja Yaml load

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -8,8 +8,8 @@ In the container you will have a dedicated Home Assistant core instance running 
 
 - [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - Docker
-  -  For Linux, macOS, or Windows 10 Pro/Enterprise/Education use the [current release version of Docker](https://docs.docker.com/install/)
-  -  Windows 10 Home requires [WSL 2](https://docs.microsoft.com/windows/wsl/wsl2-install) and the current Edge version of Docker Desktop (see instructions [here](https://docs.docker.com/docker-for-windows/wsl-tech-preview/)). This can also be used for Windows Pro/Enterprise/Education.
+  - For Linux, macOS, or Windows 10 Pro/Enterprise/Education use the [current release version of Docker](https://docs.docker.com/install/)
+  - Windows 10 Home requires [WSL 2](https://docs.microsoft.com/windows/wsl/wsl2-install) and the current Edge version of Docker Desktop (see instructions [here](https://docs.docker.com/docker-for-windows/wsl-tech-preview/)). This can also be used for Windows Pro/Enterprise/Education.
 - [Visual Studio code](https://code.visualstudio.com/)
 - [Remote - Containers (VSC Extension)][extension-link]
 
@@ -35,12 +35,12 @@ When a task is currently running (like `Run Home Assistant on port 9123` for the
 
 The available tasks are:
 
-Task | Description
--- | --
-Run Home Assistant on port 9123 | Launch Home Assistant with your custom component code and the configuration defined in `.devcontainer/configuration.yaml`.
-Run Home Assistant configuration against /config | Check the configuration.
-Upgrade Home Assistant to latest dev | Upgrade the Home Assistant core version in the container to the latest version of the `dev` branch.
-Install a specific version of Home Assistant | Install a specific version of Home Assistant core in the container.
+| Task                                             | Description                                                                                                                |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| Run Home Assistant on port 9123                  | Launch Home Assistant with your custom component code and the configuration defined in `.devcontainer/configuration.yaml`. |
+| Run Home Assistant configuration against /config | Check the configuration.                                                                                                   |
+| Upgrade Home Assistant to latest dev             | Upgrade the Home Assistant core version in the container to the latest version of the `dev` branch.                        |
+| Install a specific version of Home Assistant     | Install a specific version of Home Assistant core in the container.                                                        |
 
 ### Step by Step debugging
 
@@ -69,6 +69,14 @@ First we need to install some dependencies to get a basic Home Assistant instanc
 # start terminal in contianer
 # install pre-commit
 pre-commit install
+
+# Configure git in devcontainer
+git config user.name "John Doe"
+git cofnig user.email "john_doe@gmail.com"
+
+# Deps for pre-commit
+sudo apt update
+sudo apt install ruby
 ```
 
 #### Install HACS
@@ -84,9 +92,10 @@ wget -O - https://get.hacs.xyz | bash -
 ```
 
 #### Add Integrations
+
 - Run task: `Run Home Assistant on port 9123` described in [Tasks](#tasks)
 - Head to: http://localhost:9123
-    - create user
+  - create user
 - Add HACS integration
 - Go to HACS
   - Wait until Hacs is finished starting up.

--- a/custom_components/ui_lovelace_minimalist/process_yaml.py
+++ b/custom_components/ui_lovelace_minimalist/process_yaml.py
@@ -65,22 +65,10 @@ def load_yamll(fname, secrets=None, args={}):
                 )
             )
             stream.name = fname
-            return (
-                loader.yaml.safe_load(
-                    stream,
-                    Loader=lambda _stream: loader.SafeLineLoader(_stream, secrets),
-                )
-                or OrderedDict()
-            )
+            return loader.yaml.safe_load(stream) or OrderedDict()
         else:
             with open(fname, encoding="utf-8") as config_file:
-                return (
-                    loader.yaml.safe_load(
-                        config_file,
-                        Loader=lambda stream: loader.SafeLineLoader(stream, secrets),
-                    )
-                    or OrderedDict()
-                )
+                return loader.yaml.safe_load(config_file) or OrderedDict()
     except loader.yaml.YAMLError as exc:
         _LOGGER.error(str(exc))
         raise HomeAssistantError(exc)


### PR DESCRIPTION
Changed from yaml.load to yaml.safe_load and `loader` is not supported there!

```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 313, in async_setup
    result = await component.async_setup_entry(hass, self)  # type: ignore
  File "/config/custom_components/ui_lovelace_minimalist/__init__.py", line 83, in async_setup_entry
    return await async_initialize_integration(hass=hass, config_entry=config_entry)
  File "/config/custom_components/ui_lovelace_minimalist/__init__.py", line 61, in async_initialize_integration
    process_yaml(hass=hass, ulm=ulm)
  File "/config/custom_components/ui_lovelace_minimalist/process_yaml.py", line 215, in process_yaml
    loaded_yaml = load_yamll(fname)
  File "/config/custom_components/ui_lovelace_minimalist/process_yaml.py", line 78, in load_yamll
    loader.yaml.safe_load(
TypeError: safe_load() got an unexpected keyword argument 'Loader'
```