### PR TITLE
Adding danish to list of languages

### DIFF
--- a/custom_components/ui_lovelace_minimalist/const.py
+++ b/custom_components/ui_lovelace_minimalist/const.py
@@ -18,6 +18,7 @@ CONF_LANGUAGES = [
     "Italian",
     "Swedish",
     "Dutch",
+    "Danish",
 ]
 CONF_SIDEPANEL_ENABLED = "sidepanel_enabled"
 CONF_SIDEPANEL_TITLE = "sidepanel_title"

--- a/custom_components/ui_lovelace_minimalist/process_yaml.py
+++ b/custom_components/ui_lovelace_minimalist/process_yaml.py
@@ -43,6 +43,7 @@ LANGUAGES = {
     "Italian": "IT",
     "Swedish": "SE",
     "Dutch": "NL",
+    "Danish": "DA",
 }
 
 


### PR DESCRIPTION
I added the danish language file a few days ago, but noticed it did not show up in the list of languages in neither 0.0.2 or 0.0.3. I added the necessary code to the python files.