### PR TITLE
card_light: Use icon if it's set on the device

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_light.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_light.yaml
@@ -5,7 +5,7 @@ card_light:
     - "ulm_language_variables"
   variables:
     ulm_card_light_name: "[[[ return entity.attributes.friendly_name ]]]"
-    ulm_card_light_icon: "[[[ return 'mdi:lightbulb' ]]]"
+    ulm_card_light_icon: "[[[ return entity.attributes.icon ]]]"
     ulm_card_light_enable_collapse: false
     ulm_card_light_enable_slider: false
     ulm_card_light_enable_horizontal: false


### PR DESCRIPTION
If not specified should be using `mdi:lightbulb`. 

Needs testing. or we should move it to a if/else statment