### PR TITLE
Version: 1.0.1 of custom_card_input_number

### DIFF
--- a/custom_cards/custom_card_input_number/README.md
+++ b/custom_cards/custom_card_input_number/README.md
@@ -14,10 +14,42 @@ The `card_input_number` you can control a input_number entity
 ## Credits
 
 Author: sildehoop - 2021
-Version: 1.0.0
+Version: 1.0.1
+
+<h2 style="color: red">Braking changes</h2>
+
+<details style="color: red">
+  <summary>1.0.1</summary>
+
+```yaml
+#OLD
+- type: "custom:button-card"
+  template:
+    - card_input_number
+  variables:
+    ulm_card_input_number_name: "YOUR_NAME"
+    ulm_card_input_number_entity: "input_number.YOUR_INPUT_NUMBER"
+```
+
+```yaml
+#NEW
+- type: "custom:button-card"
+  template: card_input_number
+  entity: input_number.YOUR_INPUT_NUMBER_ENTITY
+  variables:
+    ulm_card_input_number_name: "YOUR_CARD_NAME"
+```
+
+</details>
 
 ## Changelog
 
+<details>
+<summary>1.0.1</summary>
+Added option to leave ulm_card_input_number_name empty (takes the friendly_name of the entity)
+Removed background from middle text (because it is not a button).
+Removed variables ulm_card_input_number_entity.
+</details>
 <details>
 <summary>1.0.0</summary>
 Initial release
@@ -27,11 +59,10 @@ Initial release
 
 ```yaml
 - type: "custom:button-card"
-  template:
-    - card_input_number
+  template: card_input_number
+  entity: input_number.YOUR_INPUT_NUMBER
   variables:
     ulm_card_input_number_name: "YOUR_NAME"
-    ulm_card_input_number_entity: "input_number.YOUR_INPUT_NUMBER"
 ```
 
 ## Requirements
@@ -48,122 +79,17 @@ n/a
 <th>Explanation</th>
 </tr>
 <tr>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
+<td>ulm_card_input_number_name</td>
+<td>Bathroom Ceiling Fan Threshold</td>
+<td>false</td>
+<td>The name to display on your card</td>
 </tr>
 </table>
 
 ## Template code
 
-```yaml
----
-card_input_number:
-  variables:
-    ulm_card_input_number_name: "n/a"
-  triggers_update: "all"
-  styles:
-    grid:
-      - grid-template-areas: "'item1' 'item2'"
-      - grid-template-columns: "1fr"
-      - grid-template-rows: "min-content  min-content"
-      - row-gap: "12px"
-    card:
-      - border-radius: "var(--border-radius)"
-      - box-shadow: "var(--box-shadow)"
-      - padding: "12px"
-  custom_fields:
-    item1:
-      card:
-        type: "custom:button-card"
-        template:
-          - "icon_info"
-          - "ulm_language_variables"
-          - "input_number"
-        tap_action:
-          action: "more-info"
-        entity: "[[[ return variables.ulm_card_input_number_entity ]]]"
-        name: "[[[ return variables.ulm_card_input_number_name ]]]"
-    item2:
-      card:
-        type: "custom:button-card"
-        template: "list_3_items"
-        custom_fields:
-          item1:
-            card:
-              type: "custom:button-card"
-              template: "widget_icon"
-              tap_action:
-                action: "call-service"
-                service: "input_number.decrement"
-                service_data:
-                  entity_id: "[[[ return variables.ulm_card_input_number_entity ]]]"
-              icon: "mdi:arrow-down"
-          item2:
-            card:
-              type: "custom:button-card"
-              template: "widget_text"
-              entity: "[[[ return variables.ulm_card_input_number_entity ]]]"
-              tap_action:
-                action: "call-service"
-                service: "cover.stop_cover"
-                service_data:
-                  entity_id: "[[[ return variables.ulm_card_input_number_entity ]]]"
-          item3:
-            card:
-              type: "custom:button-card"
-              template: "widget_icon"
-              tap_action:
-                action: "call-service"
-                service: "input_number.increment"
-                service_data:
-                  entity_id: "[[[ return variables.ulm_card_input_number_entity ]]]"
-              icon: "mdi:arrow-up"
+??? note "Template Code"
 
-input_number:
-  tap_action:
-    action: "more-info"
-  show_last_changed: true
-
-widget_text:
-  tap_action:
-    action: "toggle"
-  show_icon: false
-  show_label: true
-  show_name: false
-  label: >-
-    [[[
-      var unit = entity.attributes.unit_of_measurement != null ? ' ' + entity.attributes.unit_of_measurement : ''
-      if (entity.state == 'on') {
-        return variables.ulm_on;
-      } else if (entity.state == 'off') {
-        return variables.ulm_off;
-      } else if (entity.state == 'unavailable') {
-        return variables.ulm_unavailable;
-      } else if (entity.state == 'idle') {
-        return variables.ulm_idle;
-      } else if (entity.state == 'open') {
-        return variables.ulm_open;
-      } else if (entity.state == 'closed') {
-        return variables.ulm_closed;
-      } else {
-        return entity.state + unit;
-      }
-    ]]]
-  styles:
-    grid:
-      - grid-template-areas: "'l'"
-    card:
-      - box-shadow: "none"
-      - padding: "0px"
-      - background-color: "rgba(var(--color-theme),0.05)"
-      - border-radius: "14px"
-      - place-self: "center"
-      - height: "42px"
-    state:
-      - color: "rgba(var(--color-theme),0.9)"
-  size: "20px"
-  color: "var(--google-grey)"
-
-```
+    ```yaml title="custom_card_input_number.yaml"
+    --8<-- "custom_cards/custom_card_input_number/card_input_number.yaml"
+    ```

--- a/custom_cards/custom_card_input_number/card_input_number.yaml
+++ b/custom_cards/custom_card_input_number/card_input_number.yaml
@@ -1,8 +1,11 @@
 ---
 card_input_number:
   variables:
-    ulm_card_input_number_name: "n/a"
+    ulm_card_input_number_name: "[[[ return entity.attributes.friendly_name ]]]"
   triggers_update: "all"
+  show_icon: false
+  show_label: false
+  show_name: false
   styles:
     grid:
       - grid-template-areas: "'item1' 'item2'"
@@ -23,7 +26,7 @@ card_input_number:
           - "input_number"
         tap_action:
           action: "more-info"
-        entity: "[[[ return variables.ulm_card_input_number_entity ]]]"
+        entity: "[[[ return entity.entity_id ]]]"
         name: "[[[ return variables.ulm_card_input_number_name ]]]"
     item2:
       card:
@@ -38,18 +41,18 @@ card_input_number:
                 action: "call-service"
                 service: "input_number.decrement"
                 service_data:
-                  entity_id: "[[[ return variables.ulm_card_input_number_entity ]]]"
+                  entity_id: "[[[ return entity.entity_id ]]]"
               icon: "mdi:arrow-down"
           item2:
             card:
               type: "custom:button-card"
               template: "widget_text"
-              entity: "[[[ return variables.ulm_card_input_number_entity ]]]"
+              entity: "[[[ return entity.entity_id ]]]"
               tap_action:
                 action: "call-service"
                 service: "cover.stop_cover"
                 service_data:
-                  entity_id: "[[[ return variables.ulm_card_input_number_entity ]]]"
+                  entity_id: "[[[ return entity.entity_id ]]]"
           item3:
             card:
               type: "custom:button-card"
@@ -58,7 +61,7 @@ card_input_number:
                 action: "call-service"
                 service: "input_number.increment"
                 service_data:
-                  entity_id: "[[[ return variables.ulm_card_input_number_entity ]]]"
+                  entity_id: "[[[ return entity.entity_id ]]]"
               icon: "mdi:arrow-up"
 
 input_number:
@@ -97,7 +100,6 @@ widget_text:
     card:
       - box-shadow: "none"
       - padding: "0px"
-      - background-color: "rgba(var(--color-theme),0.05)"
       - border-radius: "14px"
       - place-self: "center"
       - height: "42px"


### PR DESCRIPTION
## Changelog

Added option to leave ulm_card_input_number_name empty (takes the friendly_name of the entity)
Removed background from middle text (because it is not a button).
Removed variables ulm_card_input_number_entity.

<img width="476" alt="Schermafbeelding 2022-01-27 om 11 57 22" src="https://user-images.githubusercontent.com/34340385/151345659-66a52af6-ce03-487d-ba80-a7bb4c40b14c.png">

<h2 style="color: red">Braking changes</h2>

```yaml
#OLD
- type: "custom:button-card"
  template:
    - card_input_number
  variables:
    ulm_card_input_number_name: "YOUR_NAME"
    ulm_card_input_number_entity: "input_number.YOUR_INPUT_NUMBER"
```

```yaml
#NEW
- type: "custom:button-card"
  template: card_input_number
  entity: input_number.YOUR_INPUT_NUMBER_ENTITY
  variables:
    ulm_card_input_number_name: "YOUR_CARD_NAME"
```