### PR TITLE
Hide slider if light is unavailable

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_light.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_light.yaml
@@ -59,6 +59,8 @@ card_light:
           [[[
                 if (variables.ulm_card_light_enable_collapse && entity.state == "off") {
                     return "\"item1\"";
+                } else if (variables.ulm_card_light_enable_collapse && entity.state == "unavailable") {
+                    return "\"item1\"";
                 } else if (variables.ulm_card_light_enable_horizontal) {
                     return "\"item1 item2\"";
                 } else if (variables.ulm_card_light_enable_slider) {
@@ -71,6 +73,8 @@ card_light:
           [[[
                 if (variables.ulm_card_light_enable_collapse && entity.state == "off") {
                     return "1fr";
+                } else if (variables.ulm_card_light_enable_collapse && entity.state == "unavailable") {
+                  return "1fr";
                 } else if (variables.ulm_card_light_enable_horizontal) {
                   if(variables.ulm_card_light_enable_horizontal_wide){
                     return "1fr 2fr";
@@ -85,6 +89,8 @@ card_light:
           [[[
                 if (variables.ulm_card_light_enable_collapse && entity.state == "off") {
                     return "1fr";
+                } else if (variables.ulm_card_light_enable_collapse && entity.state == "unavailable") {
+                  return "1fr";
                 } else if (variables.ulm_card_light_enable_slider && !variables.ulm_card_light_enable_horizontal) {
                     return "min-content min-content";
                 } else {
@@ -102,6 +108,8 @@ card_light:
             [[[
                   if (variables.ulm_card_light_enable_collapse && entity.state == "off") {
                       return "none";
+                  } else if (variables.ulm_card_light_enable_collapse && entity.state == "unavailable") {
+                    return "none";
                   } else if (variables.ulm_card_light_enable_slider) {
                       return "block";
                   } else {


### PR DESCRIPTION
If the ligh card has the slider enabled and `ulm_card_light_enable_collapse: true` it's supposed to be hidden when the light is off. However if the light is unavailable the slider will show up. 

![image](https://user-images.githubusercontent.com/22405505/152901371-1d02034d-06d2-491c-bae5-38e1286eac38.png)

This addes a condition to acount for entity being unavailable and hide the slider as it does when off
![image](https://user-images.githubusercontent.com/22405505/152901478-37ece963-f70a-4859-8946-f851f2cacb3d.png)

I'm by no means an expert in teplates. This works but perhaps there's a better way to do it 😅