### PR TITLE
Update card_cover_buttons.yaml

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/2-line_cards/card_cover_buttons.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/2-line_cards/card_cover_buttons.yaml
@@ -35,6 +35,11 @@ card_cover_buttons:
             card:
               type: "custom:button-card"
               template: "widget_icon"
+              state:
+                - value: 'closed'
+                  styles:
+                    icon:
+                      - color: rgba(var(--color-theme),0.4)
               tap_action:
                 action: "call-service"
                 service: "cover.close_cover"
@@ -55,6 +60,11 @@ card_cover_buttons:
             card:
               type: "custom:button-card"
               template: "widget_icon"
+              state:
+                - value: 'open'
+                  styles:
+                    icon:
+                      - color: rgba(var(--color-theme),0.4)
               tap_action:
                 action: "call-service"
                 service: "cover.open_cover"

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/2-line_cards/card_cover_buttons.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/2-line_cards/card_cover_buttons.yaml
@@ -36,10 +36,10 @@ card_cover_buttons:
               type: "custom:button-card"
               template: "widget_icon"
               state:
-                - value: 'closed'
+                - value: "closed"
                   styles:
                     icon:
-                      - color: rgba(var(--color-theme),0.4)
+                      - color: "rgba(var(--color-theme),0.4)"
               tap_action:
                 action: "call-service"
                 service: "cover.close_cover"
@@ -61,10 +61,10 @@ card_cover_buttons:
               type: "custom:button-card"
               template: "widget_icon"
               state:
-                - value: 'open'
+                - value: "open"
                   styles:
                     icon:
-                      - color: rgba(var(--color-theme),0.4)
+                      - color: "rgba(var(--color-theme),0.4)"
               tap_action:
                 action: "call-service"
                 service: "cover.open_cover"


### PR DESCRIPTION
- Added opacity to the mdi:arrow-down and mdi:arrow-up buttons wen the state is closed/open, same behaviour wen you add a cover entity to the entities card.

<img width="190" alt="Cover Card" src="https://user-images.githubusercontent.com/67138158/153418595-bc789815-3aa2-42f2-b557-462019c0ce74.png">