### PR TITLE
Update icon color to red when active only

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_thermostat.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_thermostat.yaml
@@ -178,7 +178,7 @@ card_thermostat:
                 - operator: "template"
                   value: >
                     [[[
-                      return entity.state != 'off'
+                      return (entity.attributes.hvac_action == 'cooling' || entity.attributes.hvac_action == 'heating')
                     ]]]
                   styles:
                     icon:


### PR DESCRIPTION
Previously icon would come on for any other state than "off". Ie. Auto (idle) is considered "on"/highlighted. Have changed to only color icon red when actively heating or cooling.

Further work might be done for different color/state for auto(idle).