### PR TITLE
update card_thermostat to use climate entity temperature step if present

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_thermostat.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_thermostat.yaml
@@ -275,7 +275,11 @@ card_thermostat:
                 action: "call-service"
                 service: "climate.set_temperature"
                 service_data:
-                  temperature: "[[[ return (parseFloat(states[entity.entity_id].attributes.temperature) - 0.5)  ]]]"
+                  temperature: |
+                    [[[
+                      const step = entity.attributes.target_temp_step || 0.5
+                      return (parseFloat(states[entity.entity_id].attributes.temperature) - step)
+                    ]]]
                   entity_id: "[[[ return entity.entity_id ]]]"
               state:
                 - operator: "template"
@@ -315,7 +319,11 @@ card_thermostat:
                 action: "call-service"
                 service: "climate.set_temperature"
                 service_data:
-                  temperature: "[[[ return (parseFloat(states[entity.entity_id].attributes.temperature) + 0.5)  ]]]"
+                  temperature: |
+                    [[[
+                      const step = entity.attributes.target_temp_step || 0.5
+                      return (parseFloat(states[entity.entity_id].attributes.temperature) + step)
+                    ]]]
                   entity_id: "[[[ return entity.entity_id ]]]"
               state:
                 - operator: "template"


### PR DESCRIPTION
The current fixed step of 0.5 does not work with climate entities that use an integer step and that round down fractional values, e.g. the Shelly climate entity . Setting a temp of 16.5 will be rounded down to 16. This means that the temperature can be decreased but never increased. 

This PR simply uses the entity's target_temp_step if it's defined (which it is not guaranteed to be).