### PR TITLE
card_room to use `unit_of_measurement` if present

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_room.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_room.yaml
@@ -14,7 +14,7 @@ card_room:
   label: |-
     [[[
       if (variables.label_use_temperature) {
-        return (entity.attributes.current_temperature || entity.attributes.temperature || entity.state || '-') + '°C';
+        return (entity.attributes.current_temperature || entity.attributes.temperature || entity.state || '-') + (entity.attributes.unit_of_measurement || '°C');
       } else if (variables.label_use_brightness) {
         if (entity.state){
           if (entity.state == "off"){


### PR DESCRIPTION
Update card_room to use entity attribute `unit_of_measurement` instead of static value, "°C", when available