### PR TITLE
thermostat label off mode added

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_thermostat.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_thermostat.yaml
@@ -248,14 +248,12 @@ card_thermostat:
                       var mode = variables.ulm_cooling ;
                     }else if (entity.attributes.hvac_action == 'idle'){
                       var mode = variables.ulm_idle ;
-                    }else if (entity.attributes.hvac_action == 'off'){
-                      var mode = variables.ulm_off ;
                     }else{
                       var mode = variables.ulm_unavailable;
                     }
 
                     if(entity.attributes.temperature && !variables.ulm_card_thermostat_enable_display_temperature){
-                      return (entity.attributes.current_temperature ) + '°' + ' • ' + label + ' (' + mode + ')';
+                      return (entity.attributes.current_temperature ) + '°' + ' • ' + label + (entity.state !='off' ? ' (' + mode + ')' : '');
                     }
                     return label;
                 ]]]

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_thermostat.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_thermostat.yaml
@@ -248,6 +248,8 @@ card_thermostat:
                       var mode = variables.ulm_cooling ;
                     }else if (entity.attributes.hvac_action == 'idle'){
                       var mode = variables.ulm_idle ;
+                    }else if (entity.attributes.hvac_action == 'off'){
+                      var mode = variables.ulm_off ;
                     }else{
                       var mode = variables.ulm_unavailable;
                     }


### PR DESCRIPTION
generic_thermostat includes 'off' mode.
<img width="492" alt="Ekran Resmi 2022-02-20 17 04 39" src="https://user-images.githubusercontent.com/5578433/154847307-790bd0aa-917c-4fac-935b-e905ed747a38.png">


but in label there are heating, cooling and idle options.  so it shows 'unavailable' for my devices. it shouldn't.


<img width="419" alt="Ekran Resmi 2022-02-20 17 04 58" src="https://user-images.githubusercontent.com/5578433/154847332-595524b2-1e06-454f-ae96-44c1e1d09af9.png">

i firstly added 'off' condition to 'mode'  but then i realized a device cant be in a heating, cooling or idle mode if it is off.  
so i disabled 'mode' if device entity state is off.  i think this look better.

