### PR TITLE
Add rounded corners for standard HA cards and dashboards

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-desktop/minimalist-desktop.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-desktop/minimalist-desktop.yaml
@@ -3,6 +3,7 @@ minimalist-desktop:
   # Journal
   state-icon-color: "rgb(var(--color-theme))"
   border-radius: "20px"
+  ha-card-border-radius: "20px"
   error-color: "var(--google-red)"
   warning-color: "var(--google-yellow)"
   success-color: "var(--google-green)"

--- a/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-mobile-tapbar/minimalist-mobile-tapbar.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-mobile-tapbar/minimalist-mobile-tapbar.yaml
@@ -3,6 +3,7 @@ minimalist-mobile-tapbar:
   # Journal
   state-icon-color: "rgb(var(--color-theme))"
   border-radius: "20px"
+  ha-card-border-radius: "20px"
   error-color: "var(--google-red)"
   warning-color: "var(--google-yellow)"
   success-color: "var(--google-green)"

--- a/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-mobile/minimalist-mobile.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-mobile/minimalist-mobile.yaml
@@ -3,6 +3,7 @@ minimalist-mobile:
   # Journal
   state-icon-color: "rgb(var(--color-theme))"
   border-radius: "20px"
+  ha-card-border-radius: "20px"
   error-color: "var(--google-red)"
   warning-color: "var(--google-yellow)"
   success-color: "var(--google-green)"


### PR DESCRIPTION
This PR enables rounded corners in all HA dashboards - Energy, Settings, HACS e.t.c.

## Examples:
### Theme: minimalist-desktop, dark mode, settings dashboard:
#### Before: 
![obraz](https://user-images.githubusercontent.com/55806660/155128828-fb081928-f81e-4c4d-a931-f63bd84a8c34.png)
#### After:
![obraz](https://user-images.githubusercontent.com/55806660/155128901-4ce26abd-5216-4959-9771-0cf060192d0c.png)

### Theme: minimalist-desktop, light mode, energy dashboard:
#### Before:
![obraz](https://user-images.githubusercontent.com/55806660/155129798-5bfbf5d0-df20-484a-aa9f-d6c2602d7614.png)
#### After: 
![obraz](https://user-images.githubusercontent.com/55806660/155129397-c37d258e-bc56-4739-9727-203ecc089504.png)


