### PR TITLE
Add tiny translation fix

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/popup_templates/popup_buttons/popup_button_playing.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/popup_templates/popup_buttons/popup_button_playing.yaml
@@ -2,4 +2,4 @@
 popup_button_playing:
   template: "ulm_language_variables"
   icon: "mdi:play-circle"
-  name: "Lecture"
+  name: "Playback"


### PR DESCRIPTION
Changed `name: "Lecture"` to `name: "Playback"` for the media player popup, very tiny fix (unless this was intentional)