### PR TITLE
fix(card/thermostat): use hass configured system temperature unit

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_thermostat.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_thermostat.yaml
@@ -302,13 +302,8 @@ card_thermostat:
                     var temperature = entity.attributes.temperature;
                     if (temperature == null) {
                       var temperature = '-';
-                    }else{
-                      if (temp_unit=='TEMP_CELSIUS'){
-                         return temperature + '°C'
-                      }else{
-                          return temperature + '°F'
-                      }
                     }
+                    return temperature + hass.config.unit_system.temperature;
                 ]]]
               styles:
                 card:
@@ -642,17 +637,10 @@ card_thermostat:
         label: |-
           [[[
               var temperature = entity.attributes.current_temperature;
-              var temp_unit = entity.attributes.temperature_unit;
               if (temperature == null) {
                 var temperature = '-';
               }
-              else{
-                if (temp_unit == 'TEMP_CELSIUS') {
-                  return temperature + '°C'
-                }else{
-                  return temperature + '°F'
-                }
-              }
+              return temperature + hass.config.unit_system.temperature;
           ]]]
         styles:
           card:


### PR DESCRIPTION
Two issues with commit https://github.com/UI-Lovelace-Minimalist/UI/commit/54157772e32796f64e66be287fbdc80c34935820:

1. `var temp_unit = entity.attributes.temperature_unit;` isn't defined in the top chunk, so I suspect that would be an issue
2. My thermostat (Nest) doesn't have an attribute named `temperature_unit`, I suspect others may not as well.

The proposed change uses the system configured unit, which is how the official thermostat card in Home Assistant does it.