### PR TITLE
Use entity instead of variable where possible to be consistent

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/2-line_cards/card_cover_buttons.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/2-line_cards/card_cover_buttons.yaml
@@ -1,8 +1,8 @@
 ---
 ### Card Cover With Buttons ###
 card_cover_buttons:
-  variables:
-    ulm_card_cover_buttons_name: "n/a"
+  show_name: false
+  show_icon: false
   triggers_update: "all"
   styles:
     grid:
@@ -24,8 +24,8 @@ card_cover_buttons:
           - "cover"
         tap_action:
           action: "more-info"
-        entity: "[[[ return variables.ulm_card_cover_buttons_entity ]]]"
-        name: "[[[ return variables.ulm_card_cover_buttons_name ]]]"
+        entity: "[[[ return entity.entity_id ]]]"
+        name: "[[[ return entity.attributes.friendly_name ]]]"
     item2:
       card:
         type: "custom:button-card"
@@ -44,7 +44,7 @@ card_cover_buttons:
                 action: "call-service"
                 service: "cover.close_cover"
                 service_data:
-                  entity_id: "[[[ return variables.ulm_card_cover_buttons_entity ]]]"
+                  entity_id: "[[[ return entity.entity_id ]]]"
               icon: "mdi:arrow-down"
           item2:
             card:
@@ -54,7 +54,7 @@ card_cover_buttons:
                 action: "call-service"
                 service: "cover.stop_cover"
                 service_data:
-                  entity_id: "[[[ return variables.ulm_card_cover_buttons_entity ]]]"
+                  entity_id: "[[[ return entity.entity_id ]]]"
               icon: "mdi:pause"
           item3:
             card:
@@ -69,5 +69,5 @@ card_cover_buttons:
                 action: "call-service"
                 service: "cover.open_cover"
                 service_data:
-                  entity_id: "[[[ return variables.ulm_card_cover_buttons_entity ]]]"
+                  entity_id: "[[[ return entity.entity_id ]]]"
               icon: "mdi:arrow-up"

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/2-line_cards/card_graph.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/2-line_cards/card_graph.yaml
@@ -1,9 +1,10 @@
 ---
 ### Card Graph ###
 card_graph:
+  show_name: false
+  show_icon: false
   variables:
     ulm_card_graph_color: "var(--info-color)"
-    ulm_card_graph_name: "n/a"
     ulm_card_graph_color2: "var(--info-color)"
     ulm_card_graph_name2: "n/a"
     ulm_card_graph_entity2: ""
@@ -31,15 +32,15 @@ card_graph:
             - box-shadow: "none"
             - border-radius: "var(--border-radius) var(--border-radius) 0px 0px"
             - padding: "12px"
-        entity: "[[[ return variables.ulm_card_graph_entity ]]]"
-        name: "[[[ return variables.ulm_card_graph_name ]]]"
+        entity: "[[[ return entity.entity_id ]]]"
+        name: "[[[ return entity.attributes.friendly_name ]]]"
     item2:
       card:
         type: "custom:mini-graph-card"
         entities: >
           [[[
             var ent = [];
-            ent.push(variables.ulm_card_graph_entity);
+            ent.push(entity.entity_id);
             if(variables.ulm_card_graph_entity2 != "")
               ent.push(variables.ulm_card_graph_entity2);
             return ent;

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_person.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_person.yaml
@@ -12,7 +12,7 @@ card_person:
   triggers_update: "all"
   tap_action:
     action: "more-info"
-    entity: "[[[ return variables.ulm_card_person_entity; ]]]"
+    entity: "[[[ return entity.entity_id; ]]]"
   show_label: true
   show_name: true
   label: >
@@ -20,15 +20,15 @@ card_person:
       if (variables.ulm_address !== ''){
         return states[variables.ulm_address].state
       } else {
-        let state = states[variables.ulm_card_person_entity].state;
+        let state = states[entity.entity_id].state;
         return variables["ulm_person_state_" + state] ? variables["ulm_person_state_" + state] : state;
       }
     ]]]
-  name: "[[[ return states[variables.ulm_card_person_entity].attributes.friendly_name ]]]"
-  entity: "[[[ return variables.ulm_card_person_entity; ]]]"
+  name: "[[[ return states[entity.entity_id].attributes.friendly_name ]]]"
+  entity: "[[[ return entity.entity_id; ]]]"
   icon: "mdi:face-man"
   show_entity_picture: "[[[ return variables.ulm_card_person_use_entity_picture ]]]"
-  entity_picture: "[[[ return variables.ulm_card_person_use_entity_picture != false ? states[variables.ulm_card_person_entity].attributes.entity_picture\
+  entity_picture: "[[[ return variables.ulm_card_person_use_entity_picture != false ? states[entity.entity_id].attributes.entity_picture\
     \ : null ]]]"
   styles:
     icon:
@@ -62,7 +62,7 @@ card_person:
         - line-height: "14px"
         - background-color: >
             [[[
-              if (states[variables.ulm_card_person_entity].state !== 'home') {
+              if (states[entity.entity_id].state !== 'home') {
                 return "rgba(var(--color-green),1)";
               } else {
                 return "rgba(var(--color-blue),1)";
@@ -71,11 +71,11 @@ card_person:
   custom_fields:
     notification: >
       [[[
-        if (states[variables.ulm_card_person_entity].state !== 'home') {
-          if (states[variables.ulm_card_person_entity].state === states[variables.ulm_card_person_zone1]?.attributes?.friendly_name) {
+        if (states[entity.entity_id].state !== 'home') {
+          if (states[entity.entity_id].state === states[variables.ulm_card_person_zone1]?.attributes?.friendly_name) {
             var icon = states[variables.ulm_card_person_zone1].attributes.icon !== null ? states[variables.ulm_card_person_zone1].attributes.icon : 'mdi:help-circle'
             return '<ha-icon icon="' + icon + '" style="width: 10px; height: 10px; color: var(--primary-background-color);"></ha-icon>';
-          } else if (states[variables.ulm_card_person_entity].state === states[variables.ulm_card_person_zone2]?.attributes?.friendly_name) {
+          } else if (states[entity.entity_id].state === states[variables.ulm_card_person_zone2]?.attributes?.friendly_name) {
             var icon = states[variables.ulm_card_person_zone2].attributes.icon !== null ? states[variables.ulm_card_person_zone2].attributes.icon : 'mdi:help-circle'
             return '<ha-icon icon="' + icon + '" style="width: 10px; height: 10px; color: var(--primary-background-color);"></ha-icon>';
           } else {

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/chips/chip_icon_state.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/chips/chip_icon_state.yaml
@@ -10,10 +10,10 @@ chip_icon_state:
         var icon = variables.ulm_chip_icon_state_icon;
       }
       var state = "";
-      if (states[variables.ulm_chip_icon_state_entity].state){
-        var state = states[variables.ulm_chip_icon_state_entity].state;
-        if (states[variables.ulm_chip_icon_state_entity].attributes.unit_of_measurement){
-          state += states[variables.ulm_chip_icon_state_entity].attributes.unit_of_measurement;
+      if (entity.state){
+        var state = entity.state;
+        if (entity.attributes.unit_of_measurement){
+          state += entity.attributes.unit_of_measurement;
         }
       }
       return icon + " " + state;

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/chips/chip_mdi_icon_only.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/chips/chip_mdi_icon_only.yaml
@@ -4,9 +4,9 @@ chip_mdi_icon_only:
   template: "chips"
   tap_action:
     action: "more-info"
-    entity: "[[[ return variables.ulm_chip_mdi_icon_only_entity ]]]"
+    entity: "[[[ return entity.entity_id ]]]"
   show_icon: true
-  icon: "[[[ return variables.ulm_chip_mdi_icon_only_icon ]]]"
+  icon: "[[[ return entity.attributes.icon ]]]"
   styles:
     grid:
       - grid-template-areas: "'i'"

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/chips/chip_mdi_icon_state.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/chips/chip_mdi_icon_state.yaml
@@ -4,11 +4,11 @@ chip_mdi_icon_state:
   template: "chips"
   tap_action:
     action: "more-info"
-    entity: "[[[ return variables.ulm_chip_mdi_icon_state_entity ]]]"
+    entity: "[[[ return entity.entity_id ]]]"
   triggers_update: "all"
   show_icon: true
-  icon: "[[[ return variables.ulm_chip_mdi_icon_state_icon ]]]"
-  label: "[[[ return states[variables.ulm_chip_mdi_icon_state_entity].state ]]]"
+  icon: "[[[ return entity.attributes.icon ]]]"
+  label: "[[[ return entity.state ]]]"
   styles:
     grid:
       - grid-template-areas: "'i l'"

--- a/docs/usage/cards/card_cover_buttons.md
+++ b/docs/usage/cards/card_cover_buttons.md
@@ -15,18 +15,16 @@ With the `cover-card` you have the state of your cover and on the second line UP
 
 | Variable | Default | Required         | Notes             |
 |----------|---------|------------------|-------------------|
-| ulm_card_cover_buttons_entity     |         | :material-check: | The entity_id of your cover |
-| ulm_card_cover_buttons_name |         | :material-close: | The name of your cover entity |
+| entity     |         | :material-check: | The entity_id of your cover |
+| name |         | :material-close: | The name of your cover entity |
 
 ## Usage
 
 ```yaml
 - type: 'custom:button-card'
-  template:
-    - card_cover_buttons
-  variables:
-    ulm_card_cover_buttons_name: "Cover Livingroom Window"
-    ulm_card_cover_buttons_entity: "cover.livingroom_window"
+  template: card_cover_buttons
+  entity: cover.livingroom_window
+  name: "Cover Livingroom Window"
 ```
 
 ??? note "Template Code"

--- a/docs/usage/cards/card_graph.md
+++ b/docs/usage/cards/card_graph.md
@@ -15,9 +15,9 @@ The `card_graph` shows an entity with the actual state and a *min-graph-card* in
 
 | Variable | Default | Required         | Notes             |
 |----------|---------|------------------|-------------------|
+| name      |         | :material-close: | Enable background |
+| entity      |         | :material-check: | Your entity_id for the temperature sensor |
 | ulm_card_graph_color     |         | :material-close: | This is to adjust your color value. Use a CSS varible from HA or set a color value (eg. #FFFFFF) |
-| ulm_card_graph_name      |         | :material-close: | Enable background |
-| ulm_card_graph_entity      |         | :material-check: | Your entity_id for the temperature sensor |
 | ulm_card_graph_entity2      |         | :material-close: | Your entity_id for the second temperature sensor |
 | ulm_card_graph_color2      |         | :material-close: | This is to adjust your color value of the second graph. Use a CSS varible from HA or set a color value (eg. #FFFFFF) |
 | ulm_card_graph_type      | fill | :material-close: | This is to change the appearence of the graph. Default is fill, but line, bar are valid options. |
@@ -28,10 +28,10 @@ The `card_graph` shows an entity with the actual state and a *min-graph-card* in
 ```yaml
   - type: 'custom:button-card'
     template: card_graph
+    entity: sensor.livingroom_temperature
+    name: Temperature Livingroom
     variables:
       ulm_card_graph_color: "var(--google-blue)"
-      ulm_card_graph_name: Temperature Livingroom
-      ulm_card_graph_entity: sensor.livingroom_temperature
       ulm_card_graph_color2: "var(--google-green)"
       ulm_card_graph_entity2: sensor.bedgroom_temperature
       ulm_card_graph_type: fill

--- a/docs/usage/cards/card_person.md
+++ b/docs/usage/cards/card_person.md
@@ -15,7 +15,7 @@ The `card_person` shows if a person is `home` or `not_home`. If you have setup o
 
 | Variable | Default | Required         | Notes             |
 |----------|---------|------------------|-------------------|
-| ulm_card_person_entity     |         | :material-check: | The person entity |
+| entity     |         | :material-check: | The person entity |
 | ulm_card_person_use_entity_picture |       | :material-close: | If you set this to true, the card shows the entity picture from your user, otherwise (set to false) shows the icon. Default is false. |
 | ulm_card_person_zone1     |         | :material-close: | Set another zone (beside "home") to use for the card. You can set up two zones besides "home". |
 | ulm_card_person_zone2     |         | :material-close: | Set another zone (beside "home") to use for the card. You can set up two zones besides "home". |
@@ -26,8 +26,8 @@ The `card_person` shows if a person is `home` or `not_home`. If you have setup o
 ```yaml
 - type: 'custom:button-card'
   template: card_person
+  entity: person.username
   variables:
-    ulm_card_person_entity: person.username
     ulm_card_person_use_entity_picture: true
     ulm_card_person_zone1: zone.work
     ulm_card_person_zone2: zone.school

--- a/docs/usage/chips/chip_icon_state.md
+++ b/docs/usage/chips/chip_icon_state.md
@@ -15,17 +15,17 @@ This `chip` displays an icon and a label, where the label can be any `state` of 
 
 | Variable | Default | Required         | Notes             |
 |----------|---------|------------------|-------------------|
+| entity |  | :material-check: | `entity` to link |
 | ulm_chip_icon_state_icon     |         | :material-check: | This is the icon to show. See See icons to read more about the used unicode `emojis`.  |
-|ulm_chip_icon_state_entity|  | :material-check: | Enable background |
 
 ## Usage
 
 ```yaml
 - type: 'custom:button-card'
   template: chip_icon_state
+  entity: sensor.bed_occupancy
   variables:
     ulm_chip_icon_state_icon: '🛏️'
-    ulm_chip_icon_state_entity: sensor.bed_occupancy
 ```
 
 ??? note "Template Code"

--- a/docs/usage/chips/chip_mdi_icon_only.md
+++ b/docs/usage/chips/chip_mdi_icon_only.md
@@ -15,18 +15,17 @@ This `chip` displays an icon using [mdi](https://materialdesignicons.com/).
 
 | Variable | Default | Required         | Notes             |
 |----------|---------|------------------|-------------------|
-|ulm_chip_mdi_icon_only_entity      |         | :material-check: | `entity` to link     |
-|ulm_chip_mdi_icon_only_icon        |         | :material-check: | mdi:icon to display  |
-|ulm_chip_mdi_icon_only_icon_color  | `primary-text-color` | :material-close: | Allow to change `icon` color |
+| entity                             |         | :material-check: | `entity` to link     |
+| icon                               |         | :material-check: | mdi:icon to display  |
+| ulm_chip_mdi_icon_only_icon_color  | `primary-text-color` | :material-close: | Allow to change `icon` color |
 
 ## Usage
 
 ```yaml
 - type: 'custom:button-card'
   template: chip_mdi_icon_only
-  variables:
-    ulm_chip_mdi_icon_only_entity: binary_sensor.bedroom_master_closed_door
-    ulm_chip_mdi_icon_only_icon: mdi:door
+  entity: binary_sensor.bedroom_master_closed_door
+  icon: mdi:door
 ```
 
 ??? note "Template Code"

--- a/docs/usage/chips/chip_mdi_icon_state.md
+++ b/docs/usage/chips/chip_mdi_icon_state.md
@@ -15,19 +15,18 @@ This `chip` displays an icon using [mdi](https://materialdesignicons.com/) and `
 
 | Variable | Default | Required         | Notes             |
 |----------|---------|------------------|-------------------|
-|ulm_chip_mdi_icon_state_entity     |         | :material-check: | `entity` to link |                  |
-|ulm_chip_mdi_icon_state_icon       |         | :material-close: | mdi:icon to display  |
-|ulm_chip_mdi_icon_state_icon_color | `primary-text-color` | :material-close: | Allow to change `icon` color |
-|ulm_chip_mdi_icon_state_label_color | `primary-text-color` | :material-close: | Allow to change `label` color |
+| entity     |         | :material-check: | `entity` to link |                  |
+| icon       |         | :material-close: | mdi:icon to display  |
+| ulm_chip_mdi_icon_state_icon_color | `primary-text-color` | :material-close: | Allow to change `icon` color |
+| ulm_chip_mdi_icon_state_label_color | `primary-text-color` | :material-close: | Allow to change `label` color |
 
 ## Usage
 
 ```yaml
 - type: "custom:button-card"
   template: chip_mdi_icon_state
-  variables:
-    ulm_chip_mdi_icon_state_entity: light.kitchen_lights
-    ulm_chip_mdi_icon_state_icon: mdi:lightbulb
+  entity: light.kitchen_lights
+  icon: mdi:lightbulb
 ```
 
 ??? note "Template Code"


### PR DESCRIPTION
Almost all cards use the main "entity" attribute to set the entity that should be used. 
When I tried different cards, I noticed, that some are using a ulm_*+entity variable instead. 

To be consistent and allow to easily switch between cards, I adjusted the cards to use the entity attribute. This is a breaking change and I'm not sure, how to communicate this properly. 

Fixes #478 