### PR TITLE
[popup_card_light] add color to slider

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/popup_templates/popups/popup_light_brightness.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/popup_templates/popups/popup_light_brightness.yaml
@@ -117,9 +117,33 @@ popup_light_brightness:
         left: "17%"
         thumbHorizontalPadding: "0px"
         thumbWidth: "0px"
-        mainSliderColor: "rgba(var(--color-theme),0.1)"
+        mainSliderColor: >
+          [[[
+              var color = states[variables.ulm_popup_light_entity].attributes.rgb_color;
+              if (states[variables.ulm_popup_light_entity].state == "unavailable"){
+                 return "rgba(var(--color-grey),1)";
+              }
+              else if (color){
+                 return "rgba(" + color + ",1)";
+              }
+              else{
+                return "rgba(var(--color-yellow),1)";
+              }
+          ]]]
         mainSliderColorOff: "rgba(var(--color-theme),0.1)"
-        secondarySliderColor: "var(--color-theme)"
+        secondarySliderColor: >
+          [[[
+              var color = states[variables.ulm_popup_light_entity].attributes.rgb_color;
+              if (states[variables.ulm_popup_light_entity].state == "unavailable"){
+                 return "rgba(var(--color-grey),0.2)";
+              }
+              else if (color){
+                 return "rgba(" + color + ",0.2)";
+              }
+              else{
+                return "rgba(var(--color-yellow),0.2)";
+              }
+              ]]]
         secondarySliderColorOff: "var(--color-theme)"
         card_mod:
           style: |


### PR DESCRIPTION
Idea by @AndyVRD 
Add Light Color to brightness slider
Checks for rgb_color attribute like `card_light` does
before:
![image](https://user-images.githubusercontent.com/68892092/158394259-b0a38ca1-f357-43c5-a0e2-acf9a4ea1627.png)
after:
![image](https://user-images.githubusercontent.com/68892092/158394042-e3ed390b-12ab-4a3b-9bf6-609b2aa22820.png)
