### PR TITLE
Add variables for minSet and maxSet for brightness slider on light card

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_light.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_light.yaml
@@ -8,6 +8,8 @@ card_light:
     ulm_card_light_icon: "[[[ return entity.attributes.icon ]]]"
     ulm_card_light_enable_collapse: false
     ulm_card_light_enable_slider: false
+    ulm_card_light_enable_slider_minSet: 0
+    ulm_card_light_enable_slider_maxSet: 100
     ulm_card_light_enable_horizontal: false
     ulm_card_light_enable_horizontal_wide: false
     ulm_card_light_enable_color: false
@@ -250,6 +252,8 @@ card_light:
         entity: "[[[ return entity.entity_id ]]]"
         radius: "14px"
         height: "42px"
+        minSet: "[[[ return variables.ulm_card_light_enable_slider_minSet ]]]"
+        maxSet: "[[[ return variables.ulm_card_light_enable_slider_maxSet ]]]"
         mainSliderColor: >
           [[[
               var color = entity.attributes.rgb_color;

--- a/docs/usage/cards/card_light.md
+++ b/docs/usage/cards/card_light.md
@@ -38,6 +38,8 @@ This card merges the following one :
 | ulm_card_light_name                    | `friendly_name` | :material-close: | Customize name |             |
 | ulm_card_light_icon                    | `mdi:lightbulb` | :material-close: | Customize icon |             |
 | ulm_card_light_enable_slider           | `false`         | :material-close: | Enable slider  |             |
+| ulm_card_light_enable_slider_minSet    | `0`             | :material-close: | Minimum brightness value user can select in the slider | Need `ulm_card_light_enable_slider: true` |
+| ulm_card_light_enable_slider_maxSet    | `100`           | :material-close: | Maximum brightness value user can select in the slider | Need `ulm_card_light_enable_slider: true` |
 | ulm_card_light_enable_collapse         | `false`         | :material-close: | Collapse slider when off | Need `ulm_card_light_enable_slider: true` |
 | ulm_card_light_enable_horizontal       | `false`         | :material-close: | Enable horizontal card | |
 | ulm_card_light_enable_horizontal_wide  | `false`         | :material-close: | Wider slider | Need `ulm_card_light_enable_horizontal: true` |


### PR DESCRIPTION
Add variables and option to set a min and max set value for the brightness slider on light card.
This to be able to limit the user to a specific range.

Example
```yaml
cards:
  - type: "custom:button-card"
    template: "card_light"
    entity: light.kitchen_island
    variables:
      ulm_card_light_enable_slider: true
      ulm_card_light_enable_slider_maxSet: 50
```

Build in option in my-slider https://github.com/AnthonMS/my-cards/blob/main/src/my-slider.ts