### PR TITLE
Add default hold_action to custom_card_saxel_fan

### DIFF
--- a/custom_cards/custom_card_saxel_fan/custom_card_saxel_fan.yaml
+++ b/custom_cards/custom_card_saxel_fan/custom_card_saxel_fan.yaml
@@ -54,7 +54,6 @@ custom_card_saxel_fan_blue:
                 img_cell:
                   - background-color: "rgba(250, 250, 250, 0.2)"
 
-
 # Common template, don't use
 custom_card_saxel_fan_common:
   variables:
@@ -65,6 +64,8 @@ custom_card_saxel_fan_common:
   template:
     - "ulm_language_variables"
     - "icon_info_bg"
+  hold_action:
+    action: "more-info"
   label: |-
     [[[
       if (entity.state === 'on') {


### PR DESCRIPTION
I know that by default there should be a hold_action, but it seems that this card doesn't have it. Adding the code to provide a more flexible option!

**BEFORE**
No hold_action, making other options unavailable.
![image](https://user-images.githubusercontent.com/12708526/161986844-6dc9e39a-3224-42e0-b11a-452f0ca4cb2b.png)


**AFTER**
Hold Action:
![image](https://user-images.githubusercontent.com/12708526/161986463-6bf53e90-f700-46ef-bb8b-a696086d4b94.png)
