### PR TITLE
Add generic collapsible option for media controls and volume slider

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_media_player.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_media_player.yaml
@@ -9,6 +9,7 @@ card_media_player:
     ulm_card_media_player_enable_art: false
     ulm_card_media_player_enable_controls: false
     ulm_card_media_player_enable_volume_slider: false
+    ulm_card_media_player_collapsible: false
     ulm_card_media_player_player_controls_entity: "[[[ return entity.entity_id ]]]"
     ulm_card_media_player_enable_popup: false
     ulm_card_media_player_more_info: false
@@ -60,7 +61,14 @@ card_media_player:
             }
             return rows;
           ]]]
-      - row-gap: "12px"
+      - row-gap: |-
+          [[[
+            if (!variables.ulm_card_media_player_collapsible) {
+                return "12px";
+              } else {
+                return entity.state !== "off" ? "12px" : "0px";
+              }
+          ]]]
     card:
       - border-radius: "var(--border-radius)"
       - box-shadow: "var(--box-shadow)"
@@ -76,16 +84,24 @@ card_media_player:
       item2:
         - display: |
             [[[
-              return variables.ulm_card_media_player_enable_controls
-                ? "block"
-                : "none"
+              if(variables.ulm_card_media_player_enable_controls) {
+                if(variables.ulm_card_media_player_collapsible){
+                  return entity.state === "off" ? "none" : "block";
+                }
+                return "block";
+              }
+              return "none";
             ]]]
       item3:
         - display: |
             [[[
-              return variables.ulm_card_media_player_enable_volume_slider
-                ? "block"
-                : "none"
+              if(variables.ulm_card_media_player_enable_volume_slider) {
+                if(variables.ulm_card_media_player_collapsible){
+                  return entity.state === "off" ? "none" : "block";
+                }
+                return "block";
+              }
+              return "none";
             ]]]
   custom_fields:
     item1:
@@ -391,17 +407,17 @@ card_media_player:
         radius: "14px"
         height: "42px"
         mainSliderColor: |
-                      [[[
-                        return variables.ulm_card_media_player_enable_art && states[entity.entity_id].attributes.entity_picture != null
-                        ? 'rgba(0, 0, 0, 0.2)'
-                        : 'rgba(var(--color-blue),1)'
-                      ]]]
+          [[[
+            return variables.ulm_card_media_player_enable_art && states[entity.entity_id].attributes.entity_picture != null
+            ? 'rgba(0, 0, 0, 0.2)'
+            : 'rgba(var(--color-blue),1)'
+          ]]]
         secondarySliderColor: |
-                      [[[
-                        return variables.ulm_card_media_player_enable_art && states[entity.entity_id].attributes.entity_picture != null
-                        ? 'rgba(0, 0, 0, 0.1)'
-                        : 'rgba(var(--color-blue),0.2)'
-                      ]]]
+          [[[
+            return variables.ulm_card_media_player_enable_art && states[entity.entity_id].attributes.entity_picture != null
+            ? 'rgba(0, 0, 0, 0.1)'
+            : 'rgba(var(--color-blue),0.2)'
+          ]]]
         mainSliderColorOff: "rgba(var(--color-theme),0.05)"
         secondarySliderColorOff: "rgba(var(--color-theme),0.05)"
         thumbHorizontalPadding: "0px"

--- a/docs/usage/cards/card_media_player.md
+++ b/docs/usage/cards/card_media_player.md
@@ -28,6 +28,7 @@ hide:
 | ulm_card_media_player_enable_art             | false   |                  | Enable album picture on background              |
 | ulm_card_media_player_enable_controls        | false   |                  | Enable controls bellow the title                |
 | ulm_card_media_player_enable_volume_slider   | false   |                  | Enable volume slider bellow controls            |
+| ulm_card_media_player_collapsible            | false   |                  | Controls are collapsible when state is off      |
 | ulm_card_media_player_player_controls_entity | entity  |                  | Change the controlled entity                    |
 | ulm_card_media_player_enable_popup           | false   |                  | Enable pop-up                                   |
 | ulm_card_media_player_more_info              | false   |                  | Displays artist and album info in the sub-label |


### PR DESCRIPTION
Collapsible is a generic feature in most cards so I added it in the media player too! This is to ensure that spaces are not wasted when cards are not used.

**BEFORE:**

State: OFF
![CURRENT_OFF](https://user-images.githubusercontent.com/12708526/162587016-fcdb3e87-e5ac-4e0a-854c-af01eca07775.png)

State: PLAYING - _(No Change)_
![AFTER_PLAYING](https://user-images.githubusercontent.com/12708526/162587071-008c8333-57f2-42f1-96c4-9cc14596f93f.png)

**AFTER**

State: OFF
![AFTER_OFF](https://user-images.githubusercontent.com/12708526/162587058-d3931548-ed83-42cd-abd7-fb128f37c063.png)

State: PLAYING - _(No Change)_
![AFTER_PLAYING](https://user-images.githubusercontent.com/12708526/162587064-9c75a5e0-539d-4acd-aa68-3732c7d3720e.png)

