### PR TITLE
[card_media_player] ulm_card_media_player_name wasn't honored in off state

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_media_player.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_media_player.yaml
@@ -164,6 +164,13 @@ card_media_player:
           ]]]
         state:
           - operator: "template"
+            value: "[[[ return entity.state == 'off' ]]]"
+            name: |
+              [[[
+                let name = variables.ulm_card_media_player_name || states[entity.entity_id].attributes.friendly_name;
+                return name;
+              ]]]
+          - operator: "template"
             value: "[[[ return entity.state != 'off' ]]]"
             name: |
               [[[


### PR DESCRIPTION
This will properly honor the `ulm_card_media_player_name` when `entity.state == 'off'`, and is now that same as other states