### PR TITLE
[card_thermostat] Correct typo in fan_only mode 

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_thermostat.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_thermostat.yaml
@@ -781,7 +781,7 @@ card_thermostat:
               icon: "mdi:fan"
               tap_action:
                 action: "call-service"
-                service: "climate.set_hvac_mode]"
+                service: "climate.set_hvac_mode"
                 service_data:
                   entity_id: "[[[ return entity.entity_id ]]]"
                   hvac_mode: "fan_only"


### PR DESCRIPTION
Correct typo in `fan_only` mode preventing service call