### PR TITLE
[Custom_card_esh_welcome] Fix missing entity on weather chip

### DIFF
--- a/custom_cards/custom_card_esh_welcome/custom_card_esh_welcome.yaml
+++ b/custom_cards/custom_card_esh_welcome/custom_card_esh_welcome.yaml
@@ -470,6 +470,7 @@ card_esh_welcome_topbar:
       card:
         type: "custom:button-card"
         template: "chip_weather_date"
+        entity: "[[[ return variables.ulm_weather]]]"
         variables:
           ulm_weather: "[[[ return variables.ulm_weather]]]"
         tap_action:


### PR DESCRIPTION
This fix allows the user to click on the weather chip and see more information.