### PR TITLE
Fixed service call for fan_only

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_thermostat.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_thermostat.yaml
@@ -781,7 +781,7 @@ card_thermostat:
               icon: "mdi:fan"
               tap_action:
                 action: "call-service"
-                service: "climate.set_hvac_mode]"
+                service: "climate.set_hvac_mode"
                 service_data:
                   entity_id: "[[[ return entity.entity_id ]]]"
                   hvac_mode: "fan_only"


### PR DESCRIPTION
Fixed service: "climate.set_hvac_mode" line by removing extra ] at the end for fan_only option.