### PR TITLE
Add name, icon customization to wsly_pollen card

### DIFF
--- a/custom_cards/custom_card_wsly_pollen/README.md
+++ b/custom_cards/custom_card_wsly_pollen/README.md
@@ -15,13 +15,17 @@ This is a `custom-card` to display the pollen index of the [Tomorrow.io](https:/
 ## Credits
 
 Author: wsly - 05/2022
-Version: 1.0.0
+Version: 1.0.1
 
 ## Changelog
 
 <details>
 <summary>1.0.0</summary>
 Initial release.
+</details>
+<details>
+<summary>1.0.1</summary>
+Allow customizing the name and icon of each pollen index, with localized defaults. (`*_name`, `*_icon` variables)
 </details>
 
 ## Requirements
@@ -71,6 +75,48 @@ This card uses the following integration:
 <td>Yes</td>
 <td></td>
 <td>The entity for the weed pollen index</td>
+</tr>
+<tr>
+<td>custom_card_wsly_pollen_tree_name</td>
+<td>"Trees"</td>
+<td>No</td>
+<td>"Trees" (localized)</td>
+<td>The name to display for the tree pollen index, or `false` to use the `custom_card_wsly_pollen_tree` entity's friendly name.</td>
+</tr>
+<tr>
+<td>custom_card_wsly_pollen_tree_icon</td>
+<td>"mdi:tree"</td>
+<td>No</td>
+<td>"mdi:tree"</td>
+<td>The icon to display for the tree pollen index, or `false` to use the `custom_card_wsly_pollen_tree` entity's icon.</td>
+</tr>
+<tr>
+<td>custom_card_wsly_pollen_grass_name</td>
+<td>"Grass"</td>
+<td>No</td>
+<td>"Grass" (localized)</td>
+<td>The name to display for the grass pollen index, or `false` to use the `custom_card_wsly_pollen_grass` entity's friendly name.</td>
+</tr>
+<tr>
+<td>custom_card_wsly_pollen_grass_icon</td>
+<td>"mdi:grass"</td>
+<td>No</td>
+<td>"mdi:grass"</td>
+<td>The icon to display for the grass pollen index, or `false` to use the `custom_card_wsly_pollen_grass` entity's icon.</td>
+</tr>
+<tr>
+<td>custom_card_wsly_pollen_weed_name</td>
+<td>"Weeds"</td>
+<td>No</td>
+<td>"Weeds" (localized)</td>
+<td>The name to display for the weed pollen index, or `false` to use the `custom_card_wsly_pollen_weed` entity's friendly name.</td>
+</tr>
+<tr>
+<td>custom_card_wsly_pollen_weed_icon</td>
+<td>"mdi:flower-pollen"</td>
+<td>No</td>
+<td>"mdi:flower-pollen"</td>
+<td>The icon to display for the weed pollen index, or `false` to use the `custom_card_wsly_pollen_weed` entity's icon.</td>
 </tr>
 </table>
 

--- a/custom_cards/custom_card_wsly_pollen/custom_card_wsly_pollen.yaml
+++ b/custom_cards/custom_card_wsly_pollen/custom_card_wsly_pollen.yaml
@@ -2,7 +2,9 @@
 ### Custom card Pollen ###
 custom_card_wsly_pollen:
   type: "custom:button-card"
-  template: "list_3_items"
+  template:
+    - "custom_card_wsly_pollen_language_variables"
+    - "list_3_items"
   triggers_update: "all"
   styles:
     card:
@@ -14,16 +16,22 @@ custom_card_wsly_pollen:
         type: "custom:button-card"
         template: "custom_card_wsly_pollen_item"
         entity: "[[[ return variables.custom_card_wsly_pollen_tree ]]]"
+        name: "[[[ return variables.custom_card_wsly_pollen_tree_name || states[variables.custom_card_wsly_pollen_tree].attributes.friendly_name ]]]"
+        icon: "[[[ return variables.custom_card_wsly_pollen_tree_icon || states[variables.custom_card_wsly_pollen_tree].attributes.icon ]]]"
     item2:
       card:
         type: "custom:button-card"
         template: "custom_card_wsly_pollen_item"
         entity: "[[[ return variables.custom_card_wsly_pollen_grass ]]]"
+        name: "[[[ return variables.custom_card_wsly_pollen_grass_name || states[variables.custom_card_wsly_pollen_grass].attributes.friendly_name ]]]"
+        icon: "[[[ return variables.custom_card_wsly_pollen_grass_icon || states[variables.custom_card_wsly_pollen_grass].attributes.icon ]]]"
     item3:
       card:
         type: "custom:button-card"
         template: "custom_card_wsly_pollen_item"
         entity: "[[[ return variables.custom_card_wsly_pollen_weed ]]]"
+        name: "[[[ return variables.custom_card_wsly_pollen_weed_name || states[variables.custom_card_wsly_pollen_weed].attributes.friendly_name ]]]"
+        icon: "[[[ return variables.custom_card_wsly_pollen_weed_icon || states[variables.custom_card_wsly_pollen_weed].attributes.icon ]]]"
 
 custom_card_wsly_pollen_item:
   type: "custom:button-card"

--- a/custom_cards/custom_card_wsly_pollen/languages/EN.yaml
+++ b/custom_cards/custom_card_wsly_pollen/languages/EN.yaml
@@ -8,3 +8,6 @@ custom_card_wsly_pollen_language_variables:
     custom_card_wsly_pollen_medium: "Medium"
     custom_card_wsly_pollen_high: "High"
     custom_card_wsly_pollen_very_high: "Very high"
+    custom_card_wsly_pollen_tree_name: "Trees"
+    custom_card_wsly_pollen_grass_name: "Grass"
+    custom_card_wsly_pollen_weed_name: "Weeds"

--- a/custom_cards/custom_card_wsly_pollen/languages/ES.yaml
+++ b/custom_cards/custom_card_wsly_pollen/languages/ES.yaml
@@ -8,3 +8,6 @@ custom_card_wsly_pollen_language_variables:
     custom_card_wsly_pollen_medium: "Medio"
     custom_card_wsly_pollen_high: "Alto"
     custom_card_wsly_pollen_very_high: "Muy alto"
+    custom_card_wsly_pollen_tree_name: "Árboles"
+    custom_card_wsly_pollen_grass_name: "Hierbas"
+    custom_card_wsly_pollen_weed_name: "Malezas"

--- a/custom_cards/custom_card_wsly_pollen/languages/NL.yaml
+++ b/custom_cards/custom_card_wsly_pollen/languages/NL.yaml
@@ -8,3 +8,6 @@ custom_card_wsly_pollen_language_variables:
     custom_card_wsly_pollen_medium: "Gemiddeld"
     custom_card_wsly_pollen_high: "Hoog"
     custom_card_wsly_pollen_very_high: "Extreem hoog"
+    custom_card_wsly_pollen_tree_name: "Bomen"
+    custom_card_wsly_pollen_grass_name: "Grassen"
+    custom_card_wsly_pollen_weed_name: "Kruiden"

--- a/custom_cards/custom_card_wsly_pollen/languages/de.yaml
+++ b/custom_cards/custom_card_wsly_pollen/languages/de.yaml
@@ -8,3 +8,6 @@ custom_card_wsly_pollen_language_variables:
     custom_card_wsly_pollen_medium: "Mittel"
     custom_card_wsly_pollen_high: "Hoch"
     custom_card_wsly_pollen_very_high: "Sehr hoch"
+    custom_card_wsly_pollen_tree_name: "Baumen"
+    custom_card_wsly_pollen_grass_name: "Gräser"
+    custom_card_wsly_pollen_weed_name: "Unkraut"


### PR DESCRIPTION
I really liked your customized entities in the `wsly_pollen` custom card screen shot @Wesleyl89 - but I didn't want to have to customize the entities for the tomorrow.io integration on my own, so I propose this PR to allow the custom-card to do so automatically for everyone.

(CC @13robin37, @oscfdezdz if you would kindly check my `DE.yaml` and `ES.yaml` translations? @Wesleyl89 I copied the `NL.yaml` from your screenshot.)

In this PR:
* New variables `custom_card_wsly_pollen_(tree|grass|weed)_(name|icon)`.
* Default values (i.e. if you do not specify anything) will result in output just like @Wesleyl89 's screenshot in the README, or the screenshot below with my English localized version:
* Set the variables to custom strings to override name and/or icon to your preferences.
* Set the variables to `false` to restore the original card behavior of displaying the friendly name and icon of the configured entity

Defaults (with `EN.yaml` localization):
![image](https://user-images.githubusercontent.com/1765921/171235120-a4c630d9-0150-4600-b6e8-746583949162.png)

Example Customization:
```
- type: "custom:button-card"
  template: custom_card_wsly_pollen
  variables:
    custom_card_wsly_pollen_tree: sensor.tomorrow_io_home_tree_pollen_index
    custom_card_wsly_pollen_grass: sensor.tomorrow_io_home_grass_pollen_index
    custom_card_wsly_pollen_weed: sensor.tomorrow_io_home_weed_pollen_index
    custom_card_wsly_pollen_tree_name: false
    custom_card_wsly_pollen_grass_icon: false
    custom_card_wsly_pollen_weed_name: "Hello!"
    custom_card_wsly_pollen_weed_icon: "mdi:hand-wave"
```
![image](https://user-images.githubusercontent.com/1765921/171235773-18b13b5d-1199-4503-9d72-d3b2f57ec915.png)
_(Note that the tree index shows the uncustomized, unfriendly tomorrow.io integration default, the grass index shows the default `mdi:flower-pollen` icon, and the weed index is fully customized.)_