### PR TITLE
Wrong variable names not working for custom lock card

### DIFF
--- a/custom_cards/custom_card_eraycetinay_lock/README.md
+++ b/custom_cards/custom_card_eraycetinay_lock/README.md
@@ -47,9 +47,9 @@ Version: 0.0.3
   template: "custom_card_eraycetinay_lock"
   name: "Door Lock"
   variables:
-    custom_card_eraycetinay_lock_tap_control: true
-    custom_card_eraycetinay_lock_battery_level: sensor.door_battery
-    custom_card_eraycetinay_lock_door_open: binary_sensor.door_open
+    ulm_custom_card_eraycetinay_lock_tap_control: true
+    ulm_custom_card_eraycetinay_lock_battery_level: sensor.door_battery
+    ulm_custom_card_eraycetinay_lock_door_open: binary_sensor.door_open
   triggers_update:
     - "sensor.door_battery"
     - "binary_sensor.door_open"
@@ -66,42 +66,42 @@ Version: 0.0.3
     <th>Explanation</th>
   </tr>
     <tr>
-    <td>custom_card_eraycetinay_lock_tap_control</td>
+    <td>ulm_custom_card_eraycetinay_lock_tap_control</td>
     <td>true</td>
     <td>false</td>
     <td>no</td>
     <td>Lock/Unlock on tap action</td>
   </tr>
   <tr>
-    <td>custom_card_eraycetinay_lock_only_open</td>
+    <td>ulm_custom_card_eraycetinay_lock_only_open</td>
     <td>true</td>
     <td>false</td>
     <td>no</td>
     <td>Only use the card to open the door (always sends lock.open on tap)</td>
   </tr>
   <tr>
-    <td>custom_card_eraycetinay_lock_battery_level</td>
+    <td>ulm_custom_card_eraycetinay_lock_battery_level</td>
     <td>sensor.door_battery</td>
     <td></td>
     <td>no</td>
     <td>Displays a warning when the battery is low.</td>
   </tr>
   <tr>
-    <td>custom_card_eraycetinay_lock_battery_warning</td>
+    <td>ulm_custom_card_eraycetinay_lock_battery_warning</td>
     <td>25</td>
     <td>20</td>
     <td>no</td>
     <td>At what battery percentage should the low battery warning appear.</td>
   </tr>
   <tr>
-    <td>custom_card_eraycetinay_lock_battery_warning_low</td>
+    <td>ulm_custom_card_eraycetinay_lock_battery_warning_low</td>
     <td>10</td>
     <td>5</td>
     <td>no</td>
     <td>At what battery percentage should the very low battery warning appear.</td>
   </tr>
   <tr>
-    <td>custom_card_eraycetinay_lock_door_open</td>
+    <td>ulm_custom_card_eraycetinay_lock_door_open</td>
     <td>binary_sensor.door_open</td>
     <td></td>
     <td>no</td>

--- a/custom_cards/custom_card_eraycetinay_lock/custom_card_eraycetinay_lock.yaml
+++ b/custom_cards/custom_card_eraycetinay_lock/custom_card_eraycetinay_lock.yaml
@@ -1,13 +1,12 @@
 ---
 custom_card_eraycetinay_lock:
   template:
-
     - "icon_info_bg"
     - "ulm_translation_engine"
     - "custom_card_eraycetinay_lock_language_variables"
   variables:
-    custom_card_eraycetinay_lock_battery_warning: 20
-    custom_card_eraycetinay_lock_battery_warning_low: 5
+    ulm_custom_card_eraycetinay_lock_battery_warning: 20
+    ulm_custom_card_eraycetinay_lock_battery_warning_low: 5
   tap_action:
     action: |
       [[[
@@ -89,10 +88,10 @@ custom_card_eraycetinay_lock:
         - line-height: "14px"
         - background-color: |
             [[[
-              if (variables.custom_card_eraycetinay_lock_battery_level !== undefined) {
-                if (states[variables.custom_card_eraycetinay_lock_battery_level].state <= variables.custom_card_eraycetinay_lock_battery_warning_low) {
+              if (variables.ulm_custom_card_eraycetinay_lock_battery_level !== undefined) {
+                if (states[variables.ulm_custom_card_eraycetinay_lock_battery_level].state <= variables.ulm_custom_card_eraycetinay_lock_battery_warning_low) {
                   return "rgba(var(--color-red),1)";
-                } else if (states[variables.custom_card_eraycetinay_lock_battery_level].state <= variables.custom_card_eraycetinay_lock_battery_warning) {
+                } else if (states[variables.ulm_custom_card_eraycetinay_lock_battery_level].state <= variables.ulm_custom_card_eraycetinay_lock_battery_warning) {
                   return "rgba(var(--color-yellow),1)";
                 }
               }
@@ -100,15 +99,15 @@ custom_card_eraycetinay_lock:
   custom_fields:
     notification_locked_and_opened: >
       [[[
-          if (variables.custom_card_eraycetinay_lock_door_open !== undefined && (entity.state === "locked" && states[variables.custom_card_eraycetinay_lock_door_open].state === "on")) {
-            return `<span title="${variables.custom_card_eraycetinay_lock_locked_and_opened}"><ha-icon icon="mdi:door-open" style="width: 12px; height: 12px; color: var(--primary-background-color);"></ha-icon></span>`;
+          if (variables.ulm_custom_card_eraycetinay_lock_door_open !== undefined && (entity.state === "locked" && states[variables.ulm_custom_card_eraycetinay_lock_door_open].state === "on")) {
+            return `<span title="${variables.ulm_custom_card_eraycetinay_lock_locked_and_opened}"><ha-icon icon="mdi:door-open" style="width: 12px; height: 12px; color: var(--primary-background-color);"></ha-icon></span>`;
           }
       ]]]
     notification_battery: >
       [[[
-          if (variables.custom_card_eraycetinay_lock_battery_level !== undefined) {
-            if (variables.custom_card_eraycetinay_lock_battery_warning >= states[variables.custom_card_eraycetinay_lock_battery_level].state) {
-              return `<span title="${variables.custom_card_eraycetinay_lock_battery_is_at} ${states[variables.custom_card_eraycetinay_lock_battery_level].state}%">
+          if (variables.ulm_custom_card_eraycetinay_lock_battery_level !== undefined) {
+            if (variables.ulm_custom_card_eraycetinay_lock_battery_warning >= states[variables.ulm_custom_card_eraycetinay_lock_battery_level].state) {
+              return `<span title="${variables.ulm_custom_card_eraycetinay_lock_battery_is_at} ${states[variables.ulm_custom_card_eraycetinay_lock_battery_level].state}%">
                         <ha-icon icon="mdi:battery-low" style="width: 12px; height: 12px; color: var(--primary-background-color);"></ha-icon>
                       </span>`;
             }


### PR DESCRIPTION
According to the documentation the variable names used in the template are wrong.
Example, if you try to define tap action it doesn't work since the template uses thee "ulm" prefix and the docs don't.
This PR normalizes all the variables with the "ulm" prefix.
https://ui-lovelace-minimalist.github.io/UI/usage/custom_cards/custom_card_eraycetinay_lock/