### PR TITLE
Introduce minimum spread variable for thermostat card

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_thermostat.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_thermostat.yaml
@@ -16,6 +16,7 @@ card_thermostat:
     ulm_card_thermostat_enable_horizontal: false
     ulm_card_thermostat_enable_popup: false
     ulm_card_thermostat_fan_entity: null
+    ulm_card_thermostat_minimum_temp_spread: 1
   show_icon: false
   show_name: false
   show_label: false
@@ -218,7 +219,7 @@ card_thermostat:
                         const unit = hass.config.unit_system.temperature
                         const step = entity.attributes.target_temp_step || (unit == '°F' ? 1.0 : 0.5)
                         const new_temp =  (parseFloat(entity.attributes.target_temp_high) - step)
-                        return (new_temp < entity.attributes.target_temp_low ? new_temp : entity.attributes.target_temp_low);
+                        return (new_temp - variables.ulm_card_thermostat_minimum_temp_spread < entity.attributes.target_temp_low ? new_temp - variables.ulm_card_thermostat_minimum_temp_spread : entity.attributes.target_temp_low);
                       }
                     ]]]
                   target_temp_high: |
@@ -393,7 +394,7 @@ card_thermostat:
                       const unit = hass.config.unit_system.temperature
                       const step = entity.attributes.target_temp_step || (unit == '°F' ? 1.0 : 0.5)
                       const new_temp = (parseFloat(entity.attributes.target_temp_low) + step)
-                      return (new_temp > entity.attributes.target_temp_high ? new_temp : entity.attributes.target_temp_high)
+                      return (new_temp + variables.ulm_card_thermostat_minimum_temp_spread > entity.attributes.target_temp_high ? new_temp + variables.ulm_card_thermostat_minimum_temp_spread : entity.attributes.target_temp_high)
                     ]]]
                   entity_id: "[[[ return entity.entity_id ]]]"
               state:

--- a/docs/usage/cards/card_thermostat.md
+++ b/docs/usage/cards/card_thermostat.md
@@ -42,7 +42,8 @@ This card merges the following one :
 | ulm_card_thermostat_enable_display_temperature  | `false`           | :material-close: | Display  current temperature on top right | |
 | ulm_card_thermostat_enable_horizontal           | `false`           | :material-close: | Enable horizontal card| Need `ulm_card_thermostat_enable_controls: true` |
 | ulm_card_thermostat_enable_popup                | `false`           | :material-close: | Enable `popup_thermostat` | |
-| ulm_card_thermostat_fan_entity                | `null`           | :material-close: | `fan` entity for climate if seperate entity | |
+| ulm_card_thermostat_fan_entity                  | `null`            | :material-close: | `fan` entity for climate if seperate entity | |
+| ulm_card_thermostat_minimum_temp_spread         | `1`               | :material-close: | Minimum temperature spread between low and high temperature when in `heat_cool` mode | |
 
 ## Usage
 


### PR DESCRIPTION
Some thermostats don't like when the low and high temperature at set to the same value. The minimum spread will ensure there is always that amount of difference between the `target_temp_low` & `target_temp_high`. It is also able to be set by a user if they'd prefer a higher spread (or a spread of 0).