### PR TITLE
Make inside temp optional in chip_temperature

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/chips/chip_temperature.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/chips/chip_temperature.yaml
@@ -30,6 +30,12 @@ chip_temperature:
         return temp;
       }
       var outside_temp = states[variables.ulm_chip_temperature_outside].state;
-      var inside_temp = states[variables.ulm_chip_temperature_inside].state;
-      return (icon[state] || icon["default"]) + " " + convertTemperature(outside_temp) + "° / " + convertTemperature(inside_temp) + "°" ;
+      var inside_temp = null;
+      if (variables.ulm_chip_temperature_inside) {
+        var inside_temp = states[variables.ulm_chip_temperature_inside].state;
+      }
+      var label = (icon[state] || icon["default"]) + " " + convertTemperature(outside_temp) + "°"; 
+      if (inside_temp) {
+        label = label + " / " + convertTemperature(inside_temp) + "°";
+      }
     ]]]

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/chips/chip_temperature.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/chips/chip_temperature.yaml
@@ -38,4 +38,5 @@ chip_temperature:
       if (inside_temp) {
         label = label + " / " + convertTemperature(inside_temp) + "°";
       }
+      return label;
     ]]]

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/chips/chip_temperature.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/chips/chip_temperature.yaml
@@ -32,9 +32,9 @@ chip_temperature:
       var outside_temp = states[variables.ulm_chip_temperature_outside].state;
       var inside_temp = null;
       if (variables.ulm_chip_temperature_inside) {
-        var inside_temp = states[variables.ulm_chip_temperature_inside].state;
+        inside_temp = states[variables.ulm_chip_temperature_inside].state;
       }
-      var label = (icon[state] || icon["default"]) + " " + convertTemperature(outside_temp) + "°"; 
+      var label = (icon[state] || icon["default"]) + " " + convertTemperature(outside_temp) + "°";
       if (inside_temp) {
         label = label + " / " + convertTemperature(inside_temp) + "°";
       }

--- a/docs/usage/chips/chip_temperature.md
+++ b/docs/usage/chips/chip_temperature.md
@@ -9,14 +9,14 @@ hide:
 
 ![example-image](../../assets/img/ulm_chips/chip_temperature.png){ width="500" }
 
-This `chip` is to display a weather icon together with the outside and inside temperature.
+This `chip` is to display a weather icon together with the outside and inside temperature, where the latter is optional.
 
 ## Variables
 
 | Variable | Default | Required         | Notes             |
 |----------|---------|------------------|-------------------|
 | ulm_chip_temperature_outside     |         | :material-check: | This is the sensor that provides your outside temperature. If you want to use eg. a temperature value from your weather provider, you'd need to setup a template sensor first. The state of this sensor should represent a numeric value (°C or °F doesn't matter).  |
-|ulm_chip_temperature_inside|   | :material-check: | This is the sensor that provides your inside temperature. The state of this sensor should represent a numeric value (°C or °F doesn't matter). |
+|ulm_chip_temperature_inside|   | :material-close: | This is the sensor that provides your inside temperature. The state of this sensor should represent a numeric value (°C or °F doesn't matter). |
 |ulm_chip_temperature_weather|   | :material-check: | This is the sensor for your weather entity for showing current weather conditions|
 
 ## Usage


### PR DESCRIPTION
Not all use cases have the need for an inside temperature as well as an
outside one. This change makes it that only outside temperature can be
provided.