### PR TITLE
Fix "edit page" links in documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ site_url: "https://ui-lovelace-minimalist.github.io/UI/"
 # Repository
 repo_url: "https://github.com/UI-Lovelace-Minimalist/UI"
 repo_name: "UI-Lovelace-Minimalist/UI"
-edit_uri: "edit/dev/docs"
+edit_uri: "blob/main/docs"
 
 # https://pythonrepo.com/repo/lukasgeiter-mkdocs-awesome-pages-plugin-python-documentation
 nav:


### PR DESCRIPTION
The pencil icon links to a 404 page.

Current link: [github.com/UI-Lovelace-Minimalist/UI/**edit/dev/docs**/setup/custom_actions.md](https://github.com/UI-Lovelace-Minimalist/UI/edit/dev/docs/setup/custom_actions.md)
Correct link: [github.com/UI-Lovelace-Minimalist/UI/**blob/main/docs**/setup/custom_actions.md](https://github.com/UI-Lovelace-Minimalist/UI/blob/main/docs/setup/custom_actions.md)

This PR should fix the bug.
 ____ 

![image](https://user-images.githubusercontent.com/17952318/179901798-3e72069e-3979-4c8c-af6c-aa22726b2bd9.png)
