### PR TITLE
Make hvac_action optional on ulm_translation_hvac

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/default.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/default.yaml
@@ -43,7 +43,7 @@ ulm_translation_engine:
           }
           var label = hass.resources[lang]["component." + domain + ".state._." + state];
           var translation = label ? label : state;
-          return (entity.attributes.current_temperature ) + '°' + ' • ' + translation + (entity.state !='off' ? ' (' + mode + ')' : '');
+          return (entity.attributes.current_temperature ) + '°' + ' • ' + translation + ((entity.state !='off' && mode !== undefined) ? ' (' + mode + ')' : '');
           }
       ]]]
     ulm_translation_off: "[[[ return hass.resources[hass['language']]['state.default.off']; ]]]"


### PR DESCRIPTION
Some climate entities do not have the hvac_action attribute and in those
cases the translation ends up with '(undefined)' as the mode part. This
is undesirable, and thus this PR removes it from the translation in case
there is no hvac_action attribute.