### PR TITLE
Show correct location in custom_card_person_chip

### DIFF
--- a/custom_cards/custom_card_person_chip/custom_card_person_chip.yaml
+++ b/custom_cards/custom_card_person_chip/custom_card_person_chip.yaml
@@ -13,7 +13,7 @@ custom_card_person_chip:
   label: >
     [[[
       let state = states[variables.ulm_custom_card_person_chip_entity].state;
-      return hass.resources[hass["language"]]["component.person" + ".state._." + state];
+      return hass.resources[hass["language"]]["component.person" + ".state._." + state] || state;
     ]]]
   show_entity_picture: true
   entity_picture: "[[[ return states[variables.ulm_custom_card_person_chip_entity].attributes.entity_picture ]]]"


### PR DESCRIPTION
Currently when the location has no translation it does not show a
location whatsoever. Which leaves aside the possibility of having custom
names for zones.

This patch allows showing the location name when no translation is
found.