### PR TITLE
Fix text overflowing issue in custom card "room"

### DIFF
--- a/custom_cards/custom_card_esh_room/README.md
+++ b/custom_cards/custom_card_esh_room/README.md
@@ -17,7 +17,7 @@ hide:
 - Full credit to user [bms on the forum](https://community.home-assistant.io/t/lovelace-ui-minimalist/322687/192), they created the design and base of it in full, EverythingSmartHome put it into a PR as the basis
 - beasthouse and basbruss on the EverythingSmartHome discord channel for emoji/humidity customization
 - mpeterson added support for a switch to control climate and also to remove the need to have an entity associated
-- Version: 2.0.0
+- Version: 2.0.1
 
 ## Changelog
 
@@ -30,6 +30,10 @@ Initial release
 Breaking changes!
 This change introduces two variables to allow the display of the card with no buttons, one for light, one for climate or both for light and climate.
 It also now allows the use of no entity at all.
+</details>
+<details>
+<summary>2.0.1</summary>
+Fixes text overflow issue over the climate button.
 </details>
 
 ## Description

--- a/custom_cards/custom_card_esh_room/custom_card_esh_room.yaml
+++ b/custom_cards/custom_card_esh_room/custom_card_esh_room.yaml
@@ -58,6 +58,18 @@ card_esh_room:
                 return "12px";
             }
           ]]]
+      - max-width: >-
+          [[[
+            if (variables.ulm_custom_card_esh_room_light_entity && variables.ulm_custom_card_esh_room_climate_entity) {
+                return "85%";
+            } else if (variables.ulm_custom_card_esh_room_light_entity) {
+                return "100%";
+            } else if (variables.ulm_custom_card_esh_room_climate_entity) {
+                return "85%";
+            } else {
+                return "100%";
+            }
+          ]]]
     label:
       - justify-self: "start"
       - align-self: "start"
@@ -75,6 +87,18 @@ card_esh_room:
                 return "0px";
             } else {
                 return "3px";
+            }
+          ]]]
+      - max-width: >-
+          [[[
+            if (variables.ulm_custom_card_esh_room_light_entity && variables.ulm_custom_card_esh_room_climate_entity) {
+                return "85%";
+            } else if (variables.ulm_custom_card_esh_room_light_entity) {
+                return "100%";
+            } else if (variables.ulm_custom_card_esh_room_climate_entity) {
+                return "85%";
+            } else {
+                return "100%";
             }
           ]]]
     state:


### PR DESCRIPTION
The way ellipsis overflows it allows text to overflow into the climate
button. This is especially problematic with percentage widths.

This reduces the percentage width to leave room for the correct
overflow.

Fixes #861