### PR TITLE
Custom Card "room" better text overflow and use of `ulm_actions_card`

### DIFF
--- a/custom_cards/custom_card_esh_room/README.md
+++ b/custom_cards/custom_card_esh_room/README.md
@@ -17,7 +17,7 @@ hide:
 - Full credit to user [bms on the forum](https://community.home-assistant.io/t/lovelace-ui-minimalist/322687/192), they created the design and base of it in full, EverythingSmartHome put it into a PR as the basis
 - beasthouse and basbruss on the EverythingSmartHome discord channel for emoji/humidity customization
 - mpeterson added support for a switch to control climate and also to remove the need to have an entity associated
-- Version: 2.0.1
+- Version: 2.1.0
 
 ## Changelog
 
@@ -35,6 +35,11 @@ It also now allows the use of no entity at all.
 <summary>2.0.1</summary>
 Fixes text overflow issue over the climate button.
 </details>
+<details>
+<summary>2.1.0</summary>
+- It now uses the `ulm_actions_card` template, which allows the usage of the popups wherever custom actions are set as `popup`.
+- Allow overflowing label and text to the climate button area whenever there is no climate button.
+</details>
 
 ## Description
 
@@ -51,6 +56,8 @@ This is an alternative room card to the standard one that is more rectangular th
 | label                                        |         | No       | The label to display information, this can be a template or static text  |
 | ulm_custom_card_esh_room_light_entity        |         | No       | The entity to use for the light button                                   |
 | ulm_custom_card_esh_room_climate_entity      |         | No       | The entity to use for the climate button                                 |
+| ulm_card_light_enable_popup                  | `false` | No       | Enable `popup_light`                                                     |
+| ulm_card_thermostat_enable_popup             | `false` | No       | Enable `popup_thermostat`                                                |
 
 ## Usage
 

--- a/custom_cards/custom_card_esh_room/README.md
+++ b/custom_cards/custom_card_esh_room/README.md
@@ -17,7 +17,7 @@ hide:
 - Full credit to user [bms on the forum](https://community.home-assistant.io/t/lovelace-ui-minimalist/322687/192), they created the design and base of it in full, EverythingSmartHome put it into a PR as the basis
 - beasthouse and basbruss on the EverythingSmartHome discord channel for emoji/humidity customization
 - mpeterson added support for a switch to control climate and also to remove the need to have an entity associated
-- Version: 2.0.0
+- Version: 2.0.1
 
 ## Changelog
 
@@ -30,6 +30,10 @@ Initial release
 Breaking changes!
 This change introduces two variables to allow the display of the card with no buttons, one for light, one for climate or both for light and climate.
 It also now allows the use of no entity at all.
+</details>
+<details>
+<summary>2.0.1</summary>
+Fixes text overflow issue over the climate button.
 </details>
 
 ## Description

--- a/custom_cards/custom_card_esh_room/custom_card_esh_room.yaml
+++ b/custom_cards/custom_card_esh_room/custom_card_esh_room.yaml
@@ -12,6 +12,8 @@ card_esh_room:
   variables:
     ulm_custom_card_esh_room_light_entity: null
     ulm_custom_card_esh_room_climate_entity: null
+    ulm_card_thermostat_enable_popup: false
+    ulm_card_light_enable_popup: false
   label: >-
     [[[
         if (!entity) {
@@ -29,7 +31,18 @@ card_esh_room:
       - box-shadow: "var(--box-shadow)"
       - padding: "12px"
     grid:
-      - grid-template-areas: "'i light' 'n climate' 'l climate'"
+      - grid-template-areas: >-
+          [[[
+            if (variables.ulm_custom_card_esh_room_light_entity && variables.ulm_custom_card_esh_room_climate_entity) {
+                return "'i light' 'n climate' 'l climate'";
+            } else if (variables.ulm_custom_card_esh_room_light_entity) {
+                return "'i light' 'n n' 'l l'";
+            } else if (variables.ulm_custom_card_esh_room_climate_entity) {
+                return "'i .' 'n climate' 'l climate'";
+            } else {
+                return "'i .' 'n n' 'l l'";
+            }
+          ]]]
       - grid-template-columns: "1fr 1fr"
       - grid-template-rows: "min-content"
     icon:
@@ -53,7 +66,7 @@ card_esh_room:
             } else if (variables.ulm_custom_card_esh_room_light_entity) {
                 return "12px";
             } else if (variables.ulm_custom_card_esh_room_climate_entity) {
-                return "0px";
+                return "8px";
             } else {
                 return "12px";
             }
@@ -142,10 +155,12 @@ card_esh_room:
                 - background-color: "rgba(var(--color-yellow), 0.2)"
           - value: "off"
             icon: "mdi:lightbulb-off"
-        tap_action:
-          action: "toggle"
         type: "custom:button-card"
-        template: "widget_icon"
+        template:
+          - "widget_icon"
+          - "ulm_actions_card"
+        variables:
+          ulm_card_light_enable_popup: "[[[ return variables.ulm_card_light_enable_popup; ]]]"
 
     climate:
       card:
@@ -196,10 +211,12 @@ card_esh_room:
                 - background-color: "rgba(var(--color-green), 0.2)"
           - value: "off"
             icon: "mdi:snowflake-off"
-        tap_action:
-          action: "toggle"
         type: "custom:button-card"
         styles:
           card:
             - margin-top: "5px"
-        template: "widget_icon"
+        template:
+          - "widget_icon"
+          - "ulm_actions_card"
+        variables:
+          ulm_card_thermostat_enable_popup: "[[[ return variables.ulm_card_thermostat_enable_popup; ]]]"

--- a/custom_cards/custom_card_esh_room/custom_card_esh_room.yaml
+++ b/custom_cards/custom_card_esh_room/custom_card_esh_room.yaml
@@ -58,6 +58,18 @@ card_esh_room:
                 return "12px";
             }
           ]]]
+      - max-width: >-
+          [[[
+            if (variables.ulm_custom_card_esh_room_light_entity && variables.ulm_custom_card_esh_room_climate_entity) {
+                return "85%";
+            } else if (variables.ulm_custom_card_esh_room_light_entity) {
+                return "100%";
+            } else if (variables.ulm_custom_card_esh_room_climate_entity) {
+                return "85%";
+            } else {
+                return "100%";
+            }
+          ]]]
     label:
       - justify-self: "start"
       - align-self: "start"
@@ -75,6 +87,18 @@ card_esh_room:
                 return "0px";
             } else {
                 return "3px";
+            }
+          ]]]
+      - max-width: >-
+          [[[
+            if (variables.ulm_custom_card_esh_room_light_entity && variables.ulm_custom_card_esh_room_climate_entity) {
+                return "85%";
+            } else if (variables.ulm_custom_card_esh_room_light_entity) {
+                return "100%";
+            } else if (variables.ulm_custom_card_esh_room_climate_entity) {
+                return "85%";
+            } else {
+                return "100%";
             }
           ]]]
     state:


### PR DESCRIPTION
This PR enhances the card by:
     - It now uses the `ulm_actions_card` template, which allows the usage of the popups wherever custom actions are set as `popup`.
     - Allow overflowing label and text to the climate button area whenever there is no climate button.
    
Closes #862