### PR TITLE
Revert "Fix typo in Device Tracker Custom-card doc"

### DIFF
--- a/docs/usage/custom_cards/custom_card_vncntdev_device_tracer.md
+++ b/docs/usage/custom_cards/custom_card_vncntdev_device_tracer.md
@@ -86,8 +86,8 @@ Setup [WoL integration](https://www.home-assistant.io/integrations/wake_on_lan/)
 <td>custom_card_vncntdev_device_tracker_status_as_name</td>
 <td>true</td>
 <td>true</td>
-<td>swap label and name?<br>
-default: false</td>
+<td>swap label and name?<br>default: false
+default: "mdi:server"</td>
 </tr>
 <tr>
 <td>custom_card_vncntdev_device_tracker_icon</td>


### PR DESCRIPTION
Reverts UI-Lovelace-Minimalist/UI#887

As changes to `/docs/usage/custom_cards` will not hold and are overridden by the readme files in the `/custom_cards` directory.