### PR TITLE
Enable custom popups on weather card.

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/actions/actions_card_overlay.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/actions/actions_card_overlay.yaml
@@ -6,16 +6,16 @@ ulm_actions_card_overlay:
     - "ulm_actions_card"
   styles:
     grid:
-      - position: relative
+      - position: "relative"
       - z-index: 0
     custom_fields:
       actions_card_overlay:
-        - position: absolute
-        - left: 0px
-        - top: 0px
-        - height: 100%
-        - width: 100%
-        - display: grid
+        - position: "absolute"
+        - left: "0px"
+        - top: "0px"
+        - height: "100%"
+        - width: "100"%
+        - display: "grid"
         - z-index: 10
   custom_fields:
     actions_card_overlay:
@@ -29,8 +29,8 @@ ulm_actions_card_overlay:
         show_label: false
         styles:
           card:
-            - height: 100%
-            - background: none
+            - height: "100%"
+            - background: "none"
         variables:
           ulm_input_select_option: "[[[ return variables.ulm_input_select_option; ]]]"
           ulm_input_select: "[[[ return variables.ulm_input_select; ]]]"

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/actions/actions_card_overlay.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/actions/actions_card_overlay.yaml
@@ -14,7 +14,7 @@ ulm_actions_card_overlay:
         - left: "0px"
         - top: "0px"
         - height: "100%"
-        - width: "100"%
+        - width: "100%"
         - display: "grid"
         - z-index: 10
   custom_fields:

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/actions/actions_card_overlay.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/actions/actions_card_overlay.yaml
@@ -1,0 +1,46 @@
+---
+### Overlay to enable custom actions card over other cards ###
+ulm_actions_card_overlay:
+  template:
+    - "ulm_custom_actions"
+    - "ulm_actions_card"
+  styles:
+    grid:
+      - position: relative
+      - z-index: 0
+    custom_fields:
+      actions_card_overlay:
+        - position: absolute
+        - left: 0px
+        - top: 0px
+        - height: 100%
+        - width: 100%
+        - display: grid
+        - z-index: 10
+  custom_fields:
+    actions_card_overlay:
+      card:
+        type: "custom:button-card"
+        template:
+          - "ulm_actions_card"
+        entity: "[[[ return (entity != null) ? entity.entity_id : null; ]]]"
+        show_icon: false
+        show_name: false
+        show_label: false
+        styles:
+          card:
+            - height: 100%
+            - background: none
+        variables:
+          ulm_input_select_option: "[[[ return variables.ulm_input_select_option; ]]]"
+          ulm_input_select: "[[[ return variables.ulm_input_select; ]]]"
+          ulm_card_tap_action: "[[[ return variables.ulm_card_tap_action; ]]]"
+          ulm_card_tap_haptic: "[[[ return variables.ulm_card_tap_haptic; ]]]"
+          ulm_card_tap_navigate_path: "[[[ return variables.ulm_card_tap_navigate_path; ]]]"
+          ulm_card_hold_action: "[[[ return variables.ulm_card_hold_action; ]]]"
+          ulm_card_hold_haptic: "[[[ return variables.ulm_card_hold_haptic; ]]]"
+          ulm_card_hold_navigate_path: "[[[ return variables.ulm_card_hold_navigate_path; ]]]"
+          ulm_card_double_tap_action: "[[[ return variables.ulm_card_double_tap_action; ]]]"
+          ulm_card_double_tap_haptic: "[[[ return variables.ulm_card_double_tap_haptic; ]]]"
+          ulm_card_double_tap_navigate_path: "[[[ return variables.ulm_card_double_tap_navigate_path; ]]]"
+          ulm_custom_popup: "[[[ return variables.ulm_custom_popup; ]]]"

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_weather.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_weather.yaml
@@ -1,6 +1,8 @@
 ---
 ### Card Weather ###
 card_weather:
+  template:
+    - "ulm_actions_card_overlay"
   variables:
     ulm_card_weather_backdrop: false
     ulm_card_weather_primary_info: "extrema"

--- a/docs/setup/custom_actions.md
+++ b/docs/setup/custom_actions.md
@@ -242,6 +242,17 @@ Most of the internal card templates uses this option. Take a look into the code.
     --8<-- "custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_generic.yaml"
     ```
 
+### Use template `ulm_actions_card_overlay`
+
+If you implement a custom card that is based on another Lovelace card like the 
+(weather card)[https://ui-lovelace-minimalist.github.io/UI/usage/cards/card_weather/] you can simply enable custom
+card actions by using the template `ulm_actions_card_overlay` on the card. This template adds an overlay over the whole card and
+reaction on the tap, hold, double tap actions. It also enables the integration of custom popups for the card. 
+Actions of the underlying card will be disabled by this method.
+
+The (weather card)[https://ui-lovelace-minimalist.github.io/UI/usage/cards/card_weather/] gives you an example and 
+will show the usage of this method.
+
 ### Individual implementation
 
 The following script shows the usage off all necessary variables and template that will be used by the custom actions.

--- a/docs/setup/custom_actions.md
+++ b/docs/setup/custom_actions.md
@@ -244,14 +244,10 @@ Most of the internal card templates uses this option. Take a look into the code.
 
 ### Use template `ulm_actions_card_overlay`
 
-If you implement a custom card that is based on another Lovelace card like the 
-[weather card](https://ui-lovelace-minimalist.github.io/UI/usage/cards/card_weather/) you can simply enable custom
-card actions by using the template `ulm_actions_card_overlay` on the card. This template adds an overlay over the whole card and
-reaction on the tap, hold, double tap actions. It also enables the integration of custom popups for the card. 
+If you implement a custom card that is based on another Lovelace card like the [weather card](https://ui-lovelace-minimalist.github.io/UI/usage/cards/card_weather/) you can simply enable custom card actions by using the template `ulm_actions_card_overlay` on the card. This template adds an overlay over the whole card and reaction on the tap, hold, double tap actions. It also enables the integration of custom popups for the card. 
 Actions of the underlying card will be disabled by this method.
 
-The [weather card](https://ui-lovelace-minimalist.github.io/UI/usage/cards/card_weather/) gives you an example and 
-will show the usage of this method.
+The [weather card](https://ui-lovelace-minimalist.github.io/UI/usage/cards/card_weather/) gives you an example and will show the usage of this method.
 
 ### Individual implementation
 

--- a/docs/setup/custom_actions.md
+++ b/docs/setup/custom_actions.md
@@ -245,12 +245,12 @@ Most of the internal card templates uses this option. Take a look into the code.
 ### Use template `ulm_actions_card_overlay`
 
 If you implement a custom card that is based on another Lovelace card like the 
-(weather card)[https://ui-lovelace-minimalist.github.io/UI/usage/cards/card_weather/] you can simply enable custom
+[weather card](https://ui-lovelace-minimalist.github.io/UI/usage/cards/card_weather/) you can simply enable custom
 card actions by using the template `ulm_actions_card_overlay` on the card. This template adds an overlay over the whole card and
 reaction on the tap, hold, double tap actions. It also enables the integration of custom popups for the card. 
 Actions of the underlying card will be disabled by this method.
 
-The (weather card)[https://ui-lovelace-minimalist.github.io/UI/usage/cards/card_weather/] gives you an example and 
+The [weather card](https://ui-lovelace-minimalist.github.io/UI/usage/cards/card_weather/) gives you an example and 
 will show the usage of this method.
 
 ### Individual implementation

--- a/docs/setup/custom_actions.md
+++ b/docs/setup/custom_actions.md
@@ -244,10 +244,14 @@ Most of the internal card templates uses this option. Take a look into the code.
 
 ### Use template `ulm_actions_card_overlay`
 
-If you implement a custom card that is based on another Lovelace card like the [weather card](https://ui-lovelace-minimalist.github.io/UI/usage/cards/card_weather/) you can simply enable custom card actions by using the template `ulm_actions_card_overlay` on the card. This template adds an overlay over the whole card and reaction on the tap, hold, double tap actions. It also enables the integration of custom popups for the card. 
+If you implement a custom card that is based on another Lovelace card like the
+[weather card](https://ui-lovelace-minimalist.github.io/UI/usage/cards/card_weather/) you can simply enable custom
+card actions by using the template `ulm_actions_card_overlay` on the card. This template adds an overlay over the whole card and
+reaction on the tap, hold, double tap actions. It also enables the integration of custom popups for the card.
 Actions of the underlying card will be disabled by this method.
 
-The [weather card](https://ui-lovelace-minimalist.github.io/UI/usage/cards/card_weather/) gives you an example and will show the usage of this method.
+The [weather card](https://ui-lovelace-minimalist.github.io/UI/usage/cards/card_weather/) gives you an example and
+will show the usage of this method.
 
 ### Individual implementation
 


### PR DESCRIPTION
This PR adds the possibility to enable custom action and custom popups on card that used a Lovelace card as base.

It will also solve issue #937 to enable the weather popup on the weather card (@tropics1999)