### PR TITLE
Add dynamic background color option

### DIFF
--- a/custom_cards/custom_card_esh_room/README.md
+++ b/custom_cards/custom_card_esh_room/README.md
@@ -13,7 +13,10 @@ hide:
 
 ## Credits
 
-- Authors: Everything Smart Home - 2022 and mpeterson
+- Authors:
+    - Everything Smart Home - 2022
+    - mpeterson
+    - rensknoors
 - Full credit to user [bms on the forum](https://community.home-assistant.io/t/lovelace-ui-minimalist/322687/192), they created the design and base of it in full, EverythingSmartHome put it into a PR as the basis
 - beasthouse and basbruss on the EverythingSmartHome discord channel for emoji/humidity customization
 - mpeterson added support for a switch to control climate and also to remove the need to have an entity associated
@@ -44,6 +47,10 @@ Fixes text overflow issue over the climate button.
 <summary>2.1.1</summary>
 Add support for the new popup framework while maintaining backwards compatibility with the old one.
 </details>
+<details>
+<summary>2.2.0</summary>
+Introduces a new variable that lets you set the card background to the color of a light entity.
+</details>
 
 ## Description
 
@@ -62,6 +69,7 @@ This is an alternative room card to the standard one that is more rectangular th
 | ulm_custom_card_esh_room_climate_entity      |         | No       | The entity to use for the climate button                                 |
 | ulm_card_light_enable_popup                  | `false` | No       | Enable `popup_light`                                                     |
 | ulm_card_thermostat_enable_popup             | `false` | No       | Enable `popup_thermostat`                                                |
+| ulm_card_ulm_card_dynamic_color              | `false` | No       | Enables dynamic background color (requires `ulm_custom_card_esh_room_light_entity`)       |
 
 ## Usage
 

--- a/custom_cards/custom_card_esh_room/custom_card_esh_room.yaml
+++ b/custom_cards/custom_card_esh_room/custom_card_esh_room.yaml
@@ -42,7 +42,7 @@ card_esh_room:
                 if (color && variables.ulm_card_dynamic_color) {
                   return 'rgba(' + color + ', 0.2)';
                 }
-                return 'var(--color-yellow-background)';
+                return 'rgba(var(--color-background-yellow), 0.2)';
               }
             }
             return 'var(--ha-card-background, var(--card-background-color, white))';

--- a/custom_cards/custom_card_esh_room/custom_card_esh_room.yaml
+++ b/custom_cards/custom_card_esh_room/custom_card_esh_room.yaml
@@ -230,9 +230,8 @@ card_esh_room:
                         if (color && variables.ulm_card_dynamic_color) {
                           return 'rgba(' + color + ', 0.3)';
                         }
-                        return 'rgba(var(--color-yellow), 0.2)';
                       }
-                      return 'rgba(var(--color-theme), 0.3)';
+                      return 'rgba(var(--color-yellow), 0.2)';
                     ]]]
           - value: "off"
             icon: "mdi:lightbulb-off"

--- a/custom_cards/custom_card_esh_room/custom_card_esh_room.yaml
+++ b/custom_cards/custom_card_esh_room/custom_card_esh_room.yaml
@@ -42,6 +42,7 @@ card_esh_room:
                 if (color && variables.ulm_card_dynamic_color) {
                   return 'rgba(' + color + ', 0.2)';
                 }
+                return 'var(--color-yellow-background)';
               }
             }
             return 'var(--ha-card-background, var(--card-background-color, white))';

--- a/custom_cards/custom_card_esh_room/custom_card_esh_room.yaml
+++ b/custom_cards/custom_card_esh_room/custom_card_esh_room.yaml
@@ -14,45 +14,94 @@ card_esh_room:
     ulm_custom_card_esh_room_climate_entity: null
     ulm_card_thermostat_enable_popup: false
     ulm_card_light_enable_popup: false
+    ulm_card_dynamic_color: false
   label: >-
     [[[
-        if (!entity) {
-          return "<br/>";
-        } else if (entity.state == "on"){
-          var bri = Math.round(entity.attributes.brightness / 2.55);
-          return (bri ? bri + "%" : variables.ulm_translation_state) ;
-        } else {
-          return variables.ulm_translation_state;
-        }
+      var label_entity = variables.ulm_custom_card_esh_room_light_entity
+        ? states[variables.ulm_custom_card_esh_room_light_entity]
+        : entity;
+      if (!label_entity) {
+        return "<br />";
+      } else if (label_entity.state == "on") {
+        var bri = Math.round(label_entity.attributes.brightness / 2.55);
+        return (bri ? bri + "%" : variables.ulm_translation_state);
+      } else {
+        return variables.ulm_translation_state;
+      }
     ]]]
   styles:
     card:
       - border-radius: "20px"
       - box-shadow: "var(--box-shadow)"
       - padding: "12px"
+      - background-color: >-
+          [[[
+            if (variables.ulm_custom_card_esh_room_light_entity) {
+              var color = states[variables.ulm_custom_card_esh_room_light_entity].attributes.rgb_color;
+              if (states[variables.ulm_custom_card_esh_room_light_entity].state == "on") {
+                if (color && variables.ulm_card_dynamic_color) {
+                  return 'rgba(' + color + ', 0.2)';
+                }
+              }
+            }
+            return 'var(--ha-card-background, var(--card-background-color, white))';
+          ]]]
     grid:
       - grid-template-areas: >-
           [[[
             if (variables.ulm_custom_card_esh_room_light_entity && variables.ulm_custom_card_esh_room_climate_entity) {
-                return "'i light' 'n climate' 'l climate'";
+              return "'i light' 'n climate' 'l climate'";
             } else if (variables.ulm_custom_card_esh_room_light_entity) {
-                return "'i light' 'n n' 'l l'";
+              return "'i light' 'n n' 'l l'";
             } else if (variables.ulm_custom_card_esh_room_climate_entity) {
-                return "'i .' 'n climate' 'l climate'";
+              return "'i .' 'n climate' 'l climate'";
             } else {
-                return "'i .' 'n n' 'l l'";
+              return "'i .' 'n n' 'l l'";
             }
           ]]]
       - grid-template-columns: "1fr 1fr"
       - grid-template-rows: "min-content"
     icon:
-      - color: "rgba(var(--color-theme),0.2)"
+      - filter: >-
+          [[[
+            if (variables.ulm_custom_card_esh_room_light_entity
+                && states[variables.ulm_custom_card_esh_room_light_entity].state == "on"
+                && variables.ulm_card_dynamic_color) {
+              return "contrast(0.6) saturate(1.7)";
+            }
+          ]]]
+      - color: >-
+          [[[
+            if (variables.ulm_custom_card_esh_room_light_entity) {
+              var color = states[variables.ulm_custom_card_esh_room_light_entity].attributes.rgb_color;
+              if (states[variables.ulm_custom_card_esh_room_light_entity].state == "on") {
+                if (color && variables.ulm_card_dynamic_color) {
+                  return 'rgba(' + color + ', 1)';
+                }
+                return 'rgba(var(--color-yellow), 1)';
+              }
+            }
+            return 'rgba(var(--color-theme), 0.2)';
+          ]]]
     img_cell:
-      - background-color: "rgba(var(--color-theme),0.05)"
       - border-radius: "50%"
-      - place-self: "center"
+      - place-self: "flex-start"
       - width: "42px"
       - height: "42px"
+      - margin-left: "12px"
+      - background-color: >-
+          [[[
+            if (variables.ulm_custom_card_esh_room_light_entity) {
+              var color = states[variables.ulm_custom_card_esh_room_light_entity].attributes.rgb_color;
+              if (states[variables.ulm_custom_card_esh_room_light_entity].state == "on") {
+                if (color && variables.ulm_card_dynamic_color) {
+                  return 'rgba(' + color + ', 0.3)';
+                }
+                return 'rgba(var(--color-yellow), 0.2)';
+              }
+            }
+            return 'rgba(var(--color-theme), 0.05)';
+          ]]]
     name:
       - align-self: "end"
       - justify-self: "start"
@@ -62,25 +111,47 @@ card_esh_room:
       - margin-top: >-
           [[[
             if (variables.ulm_custom_card_esh_room_light_entity && variables.ulm_custom_card_esh_room_climate_entity) {
-                return "8px";
+              return "8px";
             } else if (variables.ulm_custom_card_esh_room_light_entity) {
-                return "12px";
+              return "12px";
             } else if (variables.ulm_custom_card_esh_room_climate_entity) {
-                return "8px";
+              return "8px";
             } else {
-                return "12px";
+              return "12px";
             }
           ]]]
       - max-width: >-
           [[[
             if (variables.ulm_custom_card_esh_room_light_entity && variables.ulm_custom_card_esh_room_climate_entity) {
-                return "85%";
+              return "85%";
             } else if (variables.ulm_custom_card_esh_room_light_entity) {
-                return "100%";
+              return "100%";
             } else if (variables.ulm_custom_card_esh_room_climate_entity) {
-                return "85%";
+              return "85%";
             } else {
-                return "100%";
+              return "100%";
+            }
+          ]]]
+      - color: >-
+          [[[
+            if (variables.ulm_custom_card_esh_room_light_entity) {
+              var color = states[variables.ulm_custom_card_esh_room_light_entity].attributes.rgb_color;
+              if (states[variables.ulm_custom_card_esh_room_light_entity].state == "on") {
+                if (color && variables.ulm_card_dynamic_color) {
+                  return 'rgba(' + color + ', 1)';
+                }
+                return 'rgba(var(color-yellow-text), 1)';
+              }
+              return 'rgba(var(--color-theme), 0.6)';
+            }
+            return 'rgba(var(--color-theme), 0.6)';
+          ]]]
+      - filter: >-
+          [[[
+            if (variables.ulm_custom_card_esh_room_light_entity
+                && states[variables.ulm_custom_card_esh_room_light_entity].state == "on"
+                && variables.ulm_card_dynamic_color) {
+              return "contrast(0.6) saturate(1.7)";
             }
           ]]]
     label:
@@ -93,25 +164,25 @@ card_esh_room:
       - margin-bottom: >-
           [[[
             if (variables.ulm_custom_card_esh_room_light_entity && variables.ulm_custom_card_esh_room_climate_entity) {
-                return "0px";
+              return "0px";
             } else if (variables.ulm_custom_card_esh_room_light_entity) {
-                return "3px";
+              return "3px";
             } else if (variables.ulm_custom_card_esh_room_climate_entity) {
-                return "0px";
+              return "0px";
             } else {
-                return "3px";
+              return "3px";
             }
           ]]]
       - max-width: >-
           [[[
             if (variables.ulm_custom_card_esh_room_light_entity && variables.ulm_custom_card_esh_room_climate_entity) {
-                return "85%";
+              return "85%";
             } else if (variables.ulm_custom_card_esh_room_light_entity) {
-                return "100%";
+              return "100%";
             } else if (variables.ulm_custom_card_esh_room_climate_entity) {
-                return "85%";
+              return "85%";
             } else {
-                return "100%";
+              return "100%";
             }
           ]]]
     state:
@@ -125,20 +196,20 @@ card_esh_room:
       light:
         - display: >
             [[[
-                  if (variables.ulm_custom_card_esh_room_light_entity) {
-                      return "block";
-                  } else {
-                      return "none";
-                  }
+              if (variables.ulm_custom_card_esh_room_light_entity) {
+                  return "block";
+              } else {
+                  return "none";
+              }
             ]]]
       climate:
         - display: >
             [[[
-                  if (variables.ulm_custom_card_esh_room_climate_entity) {
-                      return "block";
-                  } else {
-                      return "none";
-                  }
+              if (variables.ulm_custom_card_esh_room_climate_entity) {
+                return "block";
+              } else {
+                return "none";
+              }
             ]]]
   custom_fields:
     light:
@@ -150,9 +221,19 @@ card_esh_room:
             icon: "mdi:lightbulb"
             styles:
               icon:
-                - color: "rgba(var(--color-yellow),1)"
+                - color: "rgba(var(--color-yellow), 1)"
               img_cell:
-                - background-color: "rgba(var(--color-yellow), 0.2)"
+                - background-color: >-
+                    [[[
+                      if (variables.ulm_custom_card_esh_room_light_entity) {
+                        var color = states[variables.ulm_custom_card_esh_room_light_entity].attributes.rgb_color;
+                        if (color && variables.ulm_card_dynamic_color) {
+                          return 'rgba(' + color + ', 0.3)';
+                        }
+                        return 'rgba(var(--color-yellow), 0.2)';
+                      }
+                      return 'rgba(var(--color-theme), 0.3)';
+                    ]]]
           - value: "off"
             icon: "mdi:lightbulb-off"
         type: "custom:button-card"
@@ -163,8 +244,7 @@ card_esh_room:
           [[[
             let vars = {};
             vars.ulm_card_light_enable_popup = variables.ulm_card_light_enable_popup;
-
-            if(variables.ulm_card_light_enable_popup) {
+            if (variables.ulm_card_light_enable_popup) {
               vars.ulm_custom_popup = {
                 'template': 'popup_light_brightness',
                 'popup_variables': {
@@ -174,7 +254,6 @@ card_esh_room:
             }
             return vars;
           ]]]
-
     climate:
       card:
         entity: "[[[ return variables.ulm_custom_card_esh_room_climate_entity ]]]"
@@ -235,8 +314,7 @@ card_esh_room:
           [[[
             let vars = {};
             vars.ulm_card_thermostat_enable_popup = variables.ulm_card_light_enable_popup;
-
-            if(variables.ulm_card_thermostat_enable_popup) {
+            if (variables.ulm_card_thermostat_enable_popup) {
               vars.ulm_custom_popup = {
                 'template': 'popup_thermostat_temperature',
                 'popup_variables': {


### PR DESCRIPTION
This adds an extra variable (`ulm_card_dynamic_color`) for the `card_esh_room` card. If this variable is set to true, the card will use the color of the light as the background color when the state of the light entity is `on`.
This variable only works if the `ulm_custom_card_esh_room_light_entity` variable is also used.

With `ulm_card_dynamic_color` disabled:
<img width="516" alt="Screenshot 2022-08-24 at 10 19 53" src="https://user-images.githubusercontent.com/14264313/186367854-1cefbb29-e299-40b4-9b11-2af812ef5bf8.png">

With `ulm_card_dynamic_color` enabled:
<img width="521" alt="Screenshot 2022-08-24 at 09 40 48" src="https://user-images.githubusercontent.com/14264313/186360227-d66c75c1-c69d-4358-b3b6-c0461e0ad87b.png">