### PR TITLE
Fix 'custom_card_bar_card' bar border radius

### DIFF
--- a/custom_cards/custom_card_bar_card/README.md
+++ b/custom_cards/custom_card_bar_card/README.md
@@ -27,6 +27,10 @@ Initial release.
 <summary>0.1.1</summary>
 Fix for UI Minimalist v1.0.1.
 </details>
+<details>
+<summary>0.1.2</summary>
+Fix border radius
+</details>
 
 ## Requirements
 

--- a/custom_cards/custom_card_bar_card/custom_card_bar_card.yaml
+++ b/custom_cards/custom_card_bar_card/custom_card_bar_card.yaml
@@ -45,9 +45,11 @@ custom_card_bar_card:
         max: "[[[ return variables.ulm_custom_card_bar_card_max ]]]"
         style: |-
           bar-card-currentbar {
+            border-radius: 0px !important;
             right: 0;
           }
           bar-card-backgroundbar {
+            border-radius: 0px !important;
             right: 0;
           }
           #states {


### PR DESCRIPTION
Before the fix:
![image](https://user-images.githubusercontent.com/23715482/187782202-2fd912ea-068f-4973-bafe-d6c0985ca518.png)

After the fix (Expected result):
![image](https://user-images.githubusercontent.com/23715482/187782505-21743644-409a-4a4e-a2ff-e5571c1ff937.png)