### PR TITLE
Binary sensor alert card state

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/internal_templates/icon_alert.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/internal_templates/icon_alert.yaml
@@ -7,7 +7,7 @@ icon_alert:
   show_name: false
   state:
     - operator: "template"
-      value: "[[[ if (entity.state == 'unavailable' || entity.state == 'on'){ return true; } ]]]"
+      value: "[[[ if (entity.state == 'unavailable' || entity.state == (variables.ulm_icon_alert_state || 'on')){ return true; } ]]]"
       styles:
         icon:
           - color: "rgba(var(--color-blue),1)"
@@ -54,7 +54,7 @@ icon_alert:
   custom_fields:
     notification: >
       [[[
-        if (entity.state =="unavailable" || entity.state == "on"){
+        if (entity.state =="unavailable" || entity.state == (variables.ulm_icon_alert_state || "on")){
           return `<ha-icon icon="mdi:exclamation" style="width: 12px; height: 12px; color: var(--primary-background-color);"></ha-icon>`
         }
       ]]]

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/internal_templates/icon_alert.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/internal_templates/icon_alert.yaml
@@ -7,7 +7,14 @@ icon_alert:
   show_name: false
   state:
     - operator: "template"
-      value: "[[[ if (entity.state == 'unavailable' || entity.state == (variables.ulm_icon_alert_state || 'on')){ return true; } ]]]"
+      value: >
+        [[[
+          var check_state = 'on';
+          if (variables.ulm_icon_alert_invert_state) {
+            check_state = 'off';
+          }
+          if (entity.state == 'unavailable' || entity.state == check_state){ return true; }
+        ]]]
       styles:
         icon:
           - color: "rgba(var(--color-blue),1)"
@@ -54,7 +61,11 @@ icon_alert:
   custom_fields:
     notification: >
       [[[
-        if (entity.state =="unavailable" || entity.state == (variables.ulm_icon_alert_state || "on")){
+        var check_state = 'on';
+          if (variables.ulm_icon_alert_invert_state) {
+            check_state = 'off';
+          }
+        if (entity.state == "unavailable" || entity.state == check_state){
           return `<ha-icon icon="mdi:exclamation" style="width: 12px; height: 12px; color: var(--primary-background-color);"></ha-icon>`
         }
       ]]]

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/internal_templates/icon_info_alert.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/internal_templates/icon_info_alert.yaml
@@ -8,7 +8,14 @@ icon_info_alert:
   show_name: true
   state:
     - operator: "template"
-      value: "[[[ if (entity.state == 'unavailable' || entity.state == (variables.ulm_icon_alert_state || 'on')){ return true; } ]]]"
+      value: >
+        [[[
+          var check_state = 'on';
+          if (variables.ulm_icon_alert_invert_state) {
+            check_state = 'off';
+          }
+          if (entity.state == 'unavailable' || entity.state == check_state){ return true; }
+        ]]]
       styles:
         icon:
           - color: "rgba(var(--color-blue),1)"
@@ -75,7 +82,11 @@ icon_info_alert:
   custom_fields:
     notification: >
       [[[
-        if (entity.state =="unavailable" || entity.state == (variables.ulm_icon_alert_state || "on")){
+        var check_state = 'on';
+          if (variables.ulm_icon_alert_invert_state) {
+            check_state = 'off';
+          }
+        if (entity.state == "unavailable" || entity.state == check_state){
           return `<ha-icon icon="mdi:exclamation" style="width: 12px; height: 12px; color: var(--primary-background-color);"></ha-icon>`
         }
       ]]]

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/internal_templates/icon_info_alert.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/internal_templates/icon_info_alert.yaml
@@ -8,7 +8,7 @@ icon_info_alert:
   show_name: true
   state:
     - operator: "template"
-      value: "[[[ if (entity.state == 'unavailable' || entity.state == 'on'){ return true; } ]]]"
+      value: "[[[ if (entity.state == 'unavailable' || entity.state == (variables.ulm_icon_alert_state || 'on')){ return true; } ]]]"
       styles:
         icon:
           - color: "rgba(var(--color-blue),1)"
@@ -75,7 +75,7 @@ icon_info_alert:
   custom_fields:
     notification: >
       [[[
-        if (entity.state =="unavailable" || entity.state == "on"){
+        if (entity.state =="unavailable" || entity.state == (variables.ulm_icon_alert_state || "on")){
           return `<ha-icon icon="mdi:exclamation" style="width: 12px; height: 12px; color: var(--primary-background-color);"></ha-icon>`
         }
       ]]]

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/internal_templates/icon_more_info_alert.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/internal_templates/icon_more_info_alert.yaml
@@ -43,7 +43,7 @@ icon_more_info_alert:
               variables:
                 ulm_input_select_option: "[[[ return variables.ulm_input_select_option; ]]]"
                 ulm_input_select: "[[[ return variables.ulm_input_select; ]]]"
-                ulm_icon_alert_state: "[[[ return variables.ulm_icon_alert_state; ]]]"
+                ulm_icon_alert_invert_state: "[[[ return variables.ulm_icon_alert_invert_state; ]]]"
                 ulm_icon_tap_action: "[[[ return variables.ulm_icon_tap_action; ]]]"
                 ulm_icon_tap_haptic: "[[[ return variables.ulm_icon_tap_haptic; ]]]"
                 ulm_icon_tap_navigate_path: "[[[ return variables.ulm_icon_tap_navigate_path; ]]]"

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/internal_templates/icon_more_info_alert.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/internal_templates/icon_more_info_alert.yaml
@@ -43,6 +43,7 @@ icon_more_info_alert:
               variables:
                 ulm_input_select_option: "[[[ return variables.ulm_input_select_option; ]]]"
                 ulm_input_select: "[[[ return variables.ulm_input_select; ]]]"
+                ulm_icon_alert_state: "[[[ return variables.ulm_icon_alert_state; ]]]"
                 ulm_icon_tap_action: "[[[ return variables.ulm_icon_tap_action; ]]]"
                 ulm_icon_tap_haptic: "[[[ return variables.ulm_icon_tap_haptic; ]]]"
                 ulm_icon_tap_navigate_path: "[[[ return variables.ulm_icon_tap_navigate_path; ]]]"

--- a/docs/usage/cards/card_binary_sensor_alert.md
+++ b/docs/usage/cards/card_binary_sensor_alert.md
@@ -19,6 +19,7 @@ The `binary-sensor-card` is to show the state (on/off, open/close, etc.) of a bi
 | ulm_show_last_changed |   | :material-close: | `true` or `false` |
 | ulm_card_binary_sensor_alert_name |   | :material-close: | Set custom Name |
 | ulm_card_binary_sensor_alert_icon |   | :material-close: | Set custom Icon |
+| ulm_icon_alert_state | "on" | :material-close: | State to alert on |
 
 !!! Warning "⚠️ Breaking Change `v1.0.1`"
 

--- a/docs/usage/cards/card_binary_sensor_alert.md
+++ b/docs/usage/cards/card_binary_sensor_alert.md
@@ -19,7 +19,7 @@ The `binary-sensor-card` is to show the state (on/off, open/close, etc.) of a bi
 | ulm_show_last_changed |   | :material-close: | `true` or `false` |
 | ulm_card_binary_sensor_alert_name |   | :material-close: | Set custom Name |
 | ulm_card_binary_sensor_alert_icon |   | :material-close: | Set custom Icon |
-| ulm_icon_alert_state | "on" | :material-close: | State to alert on |
+| ulm_icon_alert_invert_state | false | :material-close: | Invert the alert state logic so an alert is shown when the sensor is "off" |
 
 !!! Warning "⚠️ Breaking Change `v1.0.1`"
 


### PR DESCRIPTION
This introduces a variable that specifies which state icon_alert and icon_info_alert should alert on. This is useful when you want to alert on a state other than "on". For example, I use this to alert when my automation is "off".

Need to setup a test environment, but this is a handy change that I've had in a local custom card. I figured it made more sense to put into the base cards than a custom card.

If you're open to this change then I can setup the dev environment for a full test.