### PR TITLE
Fix action_card if no entity is set.

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/actions/actions_card.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/actions/actions_card.yaml
@@ -43,7 +43,7 @@ ulm_actions_card:
         if (action == 'adaptive'){
           return 'input_select.select_option';
         }
-        if(entity.entity_id.startsWith("media_player.")){
+        if((entity != null) && entity.entity_id.startsWith("media_player.")){
           return 'media_player.media_play_pause';
         }
         return variables.ulm_card_tap_service;
@@ -58,7 +58,7 @@ ulm_actions_card:
             'entity_id': variables.ulm_input_select
           };
         }
-        if(entity.entity_id.startsWith("media_player.")){
+        if((entity != null) && entity.entity_id.startsWith("media_player.")){
           return {
             'entity_id': entity.entity_id
           };
@@ -161,7 +161,7 @@ ulm_actions_card:
         if (action == 'adaptive'){
           return 'input_select.select_option';
         }
-        if(entity.entity_id.startsWith("media_player.")){
+        if((entity != null) && entity.entity_id.startsWith("media_player.")){
           return 'media_player.media_play_pause';
         }
         return variables.ulm_card_hold_service;
@@ -176,7 +176,7 @@ ulm_actions_card:
             'entity_id': variables.ulm_input_select
           };
         }
-        if(entity.entity_id.startsWith("media_player.")){
+        if((entity != null) && entity.entity_id.startsWith("media_player.")){
           return {
             'entity_id': entity.entity_id
           };
@@ -279,7 +279,7 @@ ulm_actions_card:
         if (action == 'adaptive'){
           return 'input_select.select_option';
         }
-        if(entity.entity_id.startsWith("media_player.")){
+        if((entity != null) && entity.entity_id.startsWith("media_player.")){
           return 'media_player.media_play_pause';
         }
         return variables.ulm_card_double_tap_service;
@@ -294,7 +294,7 @@ ulm_actions_card:
             'entity_id': variables.ulm_input_select
           };
         }
-        if(entity.entity_id.startsWith("media_player.")){
+        if((entity != null) && entity.entity_id.startsWith("media_player.")){
           return {
             'entity_id': entity.entity_id
           };


### PR DESCRIPTION
Hi @basbruss 

This PR fixes the custom actions if no entity is set for the card.

FYI: If the `entity.entity_id` variable is used within the custom actions than the entity must be checked first. The entity could be none (e.g., for navigation buttons) and if the  `entity_id` is used without the check the whole javascript code crashes with an exception. 
