### PR TITLE
Fix syntax error for name tap action

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/actions/actions_name.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/actions/actions_name.yaml
@@ -63,7 +63,6 @@ ulm_actions_name:
             'entity_id': entity.entity_id
           };
         }
-        }
         return variables.ulm_name_tap_service_data;
       ]]]
     browser_mod:


### PR DESCRIPTION
There is one `}` bracket too many in the `actions_name.yaml` file - removing it should fix the error described in #983 