### PR TITLE
[card_esh_welcome] Add `ulm_custom_actions` to allow custom popups

### DIFF
--- a/custom_cards/custom_card_esh_room/custom_card_esh_room.yaml
+++ b/custom_cards/custom_card_esh_room/custom_card_esh_room.yaml
@@ -240,6 +240,7 @@ card_esh_room:
         template:
           - "widget_icon"
           - "ulm_actions_card"
+          - "ulm_custom_actions"
         variables: >
           [[[
             let vars = {};
@@ -310,6 +311,7 @@ card_esh_room:
         template:
           - "widget_icon"
           - "ulm_actions_card"
+          - "ulm_custom_actions"
         variables: >
           [[[
             let vars = {};


### PR DESCRIPTION
Fixes #949 - The "elm_custom_actions" template is required to make custom pop-ups work.