### PR TITLE
Add additional temperature devices

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_room.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_room.yaml
@@ -21,7 +21,7 @@ card_room:
   label: |-
     [[[
       if (variables.label_use_temperature) {
-        return (entity?.attributes?.current_temperature || entity?.attributes?.temperature || entity?.state || '-') + (entity?.attributes?.unit_of_measurement || '°C');
+        return (entity?.attributes?.current_temperature || entity?.attributes?.temperature || entity?.attributes?.device_temperature || entity?.state || '-') + (entity?.attributes?.unit_of_measurement || '°C');
       } else if (variables.label_use_brightness && entity?.state == "on" && entity?.attributes?.brightness != null) {
         let bri = Math.round(entity?.attributes?.brightness / 2.55);
         return (bri ? bri : "0") + "%";


### PR DESCRIPTION
I have a device that records attributes.device_temperature (https://www.zigbee2mqtt.io/devices/MCCGQ11LM.html).

This is a change to allow this device to show the temperature on the room template