### PR TITLE
Fix error in layout examples

### DIFF
--- a/docs/usage/layout/index.md
+++ b/docs/usage/layout/index.md
@@ -15,7 +15,7 @@ If you want to alight cards to the center, right. Or only 1 card on the right it
 
     ```yaml
     # Card in the Center
-    horizontal_stack:
+    - type: horizontal-stack
       cards:
         - type: "custom:button-card"
           color_type: blank-card
@@ -34,7 +34,7 @@ If you want to alight cards to the center, right. Or only 1 card on the right it
 
     ```yaml
     # Card in the Center
-    horizontal_stack:
+    - type: horizontal-stack
       cards:
         - type: "custom:button-card"
           color_type: blank-card
@@ -50,7 +50,7 @@ If you want to alight cards to the center, right. Or only 1 card on the right it
 
     ```yaml
     # Card in the Center
-    horizontal_stack:
+    - type: horizontal-stack
       cards:
         - type: custom:button-card
           template: chip_icon_label


### PR DESCRIPTION
This fixes an error for the layout examples, so that they can be copied and pasted without receiving any errors.