### PR TITLE
Fixed depracated use of speedtestdotnet.speedtest service and added dutch language

### DIFF
--- a/custom_cards/custom_card_irmajavi_speedtest/custom_card_irmajavi_speedtest.yaml
+++ b/custom_cards/custom_card_irmajavi_speedtest/custom_card_irmajavi_speedtest.yaml
@@ -73,7 +73,9 @@ custom_card_irmajavi_speedtest:
         type: "custom:button-card"
         tap_action:
           action: "call-service"
-          service: "speedtestdotnet.speedtest"
+          service: "homeassistant.update_entity"
+          service_data:
+            entity_id: sensor.speedtest_download
         color: "var(--google-grey)"
         show_icon: true
         show_label: false

--- a/custom_cards/custom_card_irmajavi_speedtest/languages/nl.yaml
+++ b/custom_cards/custom_card_irmajavi_speedtest/languages/nl.yaml
@@ -1,0 +1,6 @@
+---
+ulm_custom_card_irmajavi_speedtest_language_variables:
+  variables:
+    ulm_custom_card_irmajavi_speedtest_speedtest: "Speedtest"
+    ulm_custom_card_irmajavi_speedtest_download: "Download snelheid"
+    ulm_custom_card_irmajavi_speedtest_upload: "Upload snelheid"


### PR DESCRIPTION
HA notifies:

The speedtest service is being removed
Update any automations or scripts that use this service to instead use the homeassistant.update_entity service with a target Speedtest entity_id. Then, click SUBMIT below to mark this issue as resolved.