### PR TITLE
Updated custom esh_room card to support light icon customization (issue 1023)

### DIFF
--- a/custom_cards/custom_card_esh_room/README.md
+++ b/custom_cards/custom_card_esh_room/README.md
@@ -67,6 +67,8 @@ This is an alternative room card to the standard one that is more rectangular th
 | label                                        |         | No       | The label to display information, this can be a template or static text  |
 | ulm_custom_card_esh_room_light_entity        |         | No       | The entity to use for the light button                                   |
 | ulm_custom_card_esh_room_climate_entity      |         | No       | The entity to use for the climate button                                 |
+| ulm_card_esh_room_light_icon_on              |         | No       | Customize the light ON icon                                              |
+| ulm_card_esh_room_light_icon_off             |         | No       | Customize the light OFF icon                                             |
 | ulm_card_light_enable_popup                  | `false` | No       | Enable `popup_light`                                                     |
 | ulm_card_thermostat_enable_popup             | `false` | No       | Enable `popup_thermostat`                                                |
 | ulm_card_dynamic_color                       | `false` | No       | Enables dynamic background color (requires `ulm_custom_card_esh_room_light_entity`)       |

--- a/custom_cards/custom_card_esh_room/custom_card_esh_room.yaml
+++ b/custom_cards/custom_card_esh_room/custom_card_esh_room.yaml
@@ -16,7 +16,7 @@ card_esh_room:
     ulm_card_light_enable_popup: false
     ulm_card_dynamic_color: false
     ulm_card_esh_room_light_icon_on: "mdi:lightbulb"
-    ulm_card_esh_room_light_icon_off: "mdi:lightbulb-off" 
+    ulm_card_esh_room_light_icon_off: "mdi:lightbulb-off"
   label: >-
     [[[
       var label_entity = variables.ulm_custom_card_esh_room_light_entity

--- a/custom_cards/custom_card_esh_room/custom_card_esh_room.yaml
+++ b/custom_cards/custom_card_esh_room/custom_card_esh_room.yaml
@@ -15,6 +15,8 @@ card_esh_room:
     ulm_card_thermostat_enable_popup: false
     ulm_card_light_enable_popup: false
     ulm_card_dynamic_color: false
+    ulm_card_esh_room_light_icon_on: "mdi:lightbulb"
+    ulm_card_esh_room_light_icon_off: "mdi:lightbulb-off" 
   label: >-
     [[[
       var label_entity = variables.ulm_custom_card_esh_room_light_entity
@@ -219,7 +221,7 @@ card_esh_room:
         name: "[[[ return name ]]]"
         state:
           - value: "on"
-            icon: "mdi:lightbulb"
+            icon: "[[[ return variables.ulm_card_esh_room_light_icon_on; ]]]"
             styles:
               icon:
                 - color: "rgba(var(--color-yellow), 1)"
@@ -235,7 +237,7 @@ card_esh_room:
                       return 'rgba(var(--color-yellow), 0.2)';
                     ]]]
           - value: "off"
-            icon: "mdi:lightbulb-off"
+            icon: "[[[ return variables.ulm_card_esh_room_light_icon_off; ]]]"
         type: "custom:button-card"
         template:
           - "widget_icon"


### PR DESCRIPTION
Hi,

I needed to customize the light icon on the right for the esm_room card. I added the two new optional variables to customize it.
This was also requested by another user at this post
https://github.com/UI-Lovelace-Minimalist/UI/issues/1023

I hope it is good :)
Cheers
Cristian