### PR TITLE
Update eraycetinay custom lock card to include garage door cover states

### DIFF
--- a/custom_cards/custom_card_eraycetinay_lock/custom_card_eraycetinay_lock.yaml
+++ b/custom_cards/custom_card_eraycetinay_lock/custom_card_eraycetinay_lock.yaml
@@ -39,7 +39,7 @@ custom_card_eraycetinay_lock:
   state:
     - operator: "template"
       value: |
-        [[[ return entity.state == ("unlocked" || "open"); ]]]
+        [[[ return entity.state == ("unlocked" || "open" || "opened"); ]]]
       styles:
         icon:
           - color: "rgba(var(--color-yellow),1)"
@@ -47,7 +47,7 @@ custom_card_eraycetinay_lock:
           - background-color: "rgba(var(--color-yellow), 0.2)"
     - operator: "template"
       value: |
-        [[[ return entity.state == "locked"; ]]]
+        [[[ return entity.state == "locked" || "closed"; ]]]
       styles:
         icon:
           - color: "rgba(var(--color-green),1)"

--- a/docs/usage/cards/card_light.md
+++ b/docs/usage/cards/card_light.md
@@ -49,6 +49,7 @@ To use `popup_light` you need to set the variable `ulm_card_light_enable_popup` 
 | ulm_card_light_enable_popup           | `false`         | :material-close: | Enable `popup_light`                                   |                                               |
 | ulm_card_light_enable_popup_tap       | `false`         | :material-close: | Enable `popup_light` on simple icon tap                |                                               |
 | ulm_card_light_color_palette          |                 | :material-close: | Add `select` entity to control color palette               |                                               |
+
 ## Usage
 
 ```yaml

--- a/docs/usage/popups/popup_light.md
+++ b/docs/usage/popups/popup_light.md
@@ -24,6 +24,7 @@ This popup is displayed using ``hold_action`` and it is compatible with the foll
 ##### How to use
 
 ##### Variables
+
 | Variable/Entity                       | Default         | Required         | Notes                                                  | Requirement                                   |
 | ------------------------------------- | --------------- | ---------------- | ------------------------------------------------------ | --------------------------------------------- |
 | ulm_card_light_color_palette          |                 | :material-close: | Add `select` entity to control color palette               |                                               |


### PR DESCRIPTION
Currently for a cover the states are closed and opened. Adding this to the card in order to have colors set properly. Original code by @sisimomo 

Also updated 2 files to fixing missing returns which was causing one of the checks to fail

![image](https://user-images.githubusercontent.com/8870252/200150538-770a4186-f2c8-4212-b3c0-df40a2f265fd.png)
