### PR TITLE
Added language field for use in custom_cards

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/cn.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/cn.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language: "中國人"
     ulm_currency: "￥"
     ulm_updates_available: "有更新!"
     ulm_no_updates_available: "无更新"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/cn.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/cn.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language_code: "cn"
     ulm_language: "中國人"
     ulm_currency: "￥"
     ulm_updates_available: "有更新!"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/cs.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/cs.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language_code: "cs"
     ulm_language: "Čeština"
     ulm_currency: "Kč"
     ulm_updates_available: "Aktualizace k dispozici!"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/cs.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/cs.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language: "Čeština"
     ulm_currency: "Kč"
     ulm_updates_available: "Aktualizace k dispozici!"
     ulm_no_updates_available: "Nejsou k dispozici žádné aktualizace"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/da.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/da.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language_code: "da"
     ulm_language: "Dansk"
     ulm_currency: "kr"
     ulm_updates_available: "Opdatering tilgængelig"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/da.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/da.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language: "Dansk"
     ulm_currency: "kr"
     ulm_updates_available: "Opdatering tilgængelig"
     ulm_no_updates_available: "Ingen opdateringer"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/de.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/de.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language: "Deutsch"
     ulm_currency: "€"
     ulm_updates_available: "Updates verfügbar!"
     ulm_no_updates_available: "Keine Updates verfügbar"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/de.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/de.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language_code: "de"
     ulm_language: "Deutsch"
     ulm_currency: "€"
     ulm_updates_available: "Updates verfügbar!"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/default.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/default.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_translation_engine:
   variables:
+    ulm_language: "Default"
     ulm_translation_back: "[[[ return hass.resources[hass['language']]['ui.common.back']; ]]]"
     ulm_translation_brightness: "[[[ return hass.resources[hass['language']]['ui.card.light.brightness']; ]]]"
     ulm_translation_color_temperature: "[[[ return hass.resources[hass['language']]['ui.card.light.color_temperature']; ]]]"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/default.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/default.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_translation_engine:
   variables:
+    ulm_language_code: "default"
     ulm_language: "Default"
     ulm_translation_back: "[[[ return hass.resources[hass['language']]['ui.common.back']; ]]]"
     ulm_translation_brightness: "[[[ return hass.resources[hass['language']]['ui.card.light.brightness']; ]]]"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/en.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/en.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language_code: "en"
     ulm_language: "English"
     ulm_currency: "$"
     ulm_updates_available: "Updates available!"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/en.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/en.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language: "English"
     ulm_currency: "$"
     ulm_updates_available: "Updates available!"
     ulm_no_updates_available: "No updates available"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/es.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/es.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language: "Español"
     ulm_currency: "€"
     ulm_updates_available: "¡Actualización disponible!"
     ulm_no_updates_available: "No hay actualizaciones"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/es.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/es.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language_code: "es"
     ulm_language: "Español"
     ulm_currency: "€"
     ulm_updates_available: "¡Actualización disponible!"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/fi.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/fi.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language: "Suomalainen"
     ulm_currency: "€"
     ulm_updates_available: "Päivityksiä saatavilla!"
     ulm_no_updates_available: "Ei päivityksiä saatavilla"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/fi.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/fi.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language_code: "fi"
     ulm_language: "Suomalainen"
     ulm_currency: "€"
     ulm_updates_available: "Päivityksiä saatavilla!"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/fr.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/fr.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language_code: "fr"
     ulm_language: "Français"
     ulm_currency: "€"
     ulm_updates_available: "Mises à jour disponibles!"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/fr.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/fr.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language: "Français"
     ulm_currency: "€"
     ulm_updates_available: "Mises à jour disponibles!"
     ulm_no_updates_available: "Pas de nouvelle mise à jour"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/it.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/it.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language: "Italiano"
     ulm_currency: "€"
     ulm_updates_available: "Aggiornamento Disponibile!"
     ulm_no_updates_available: "Non ci sono aggiornamenti"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/it.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/it.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language_code: "it"
     ulm_language: "Italiano"
     ulm_currency: "€"
     ulm_updates_available: "Aggiornamento Disponibile!"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/nl.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/nl.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language: "Nederlands"
     ulm_currency: "€"
     ulm_updates_available: "Updates beschikbaar!"
     ulm_no_updates_available: "Geen updates beschikbaar"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/nl.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/nl.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language_code: "nl"
     ulm_language: "Nederlands"
     ulm_currency: "€"
     ulm_updates_available: "Updates beschikbaar!"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/no.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/no.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language_code: "no"
     ulm_language: "Norsk"
     ulm_currency: "NOK"
     ulm_updates_available: "Updates available!"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/no.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/no.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language: "Norsk"
     ulm_currency: "NOK"
     ulm_updates_available: "Updates available!"
     ulm_no_updates_available: "No updates available"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/pl.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/pl.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language_code: "pl"
     ulm_language: "Polski"
     ulm_currency: "PLN"
     ulm_updates_available: "Aktualizacja jest dostępna!"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/pl.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/pl.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language: "Polski"
     ulm_currency: "PLN"
     ulm_updates_available: "Aktualizacja jest dostępna!"
     ulm_no_updates_available: "Brak dostępnych aktualizacji"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/pt-BR.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/pt-BR.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language: "Português (BR)"
     ulm_currency: "R$"
     ulm_updates_available: "Atualizações disponíveis!"
     ulm_no_updates_available: "Sem atualizações disponíveis"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/pt-BR.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/pt-BR.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language_code: "pt-br"
     ulm_language: "Português (BR)"
     ulm_currency: "R$"
     ulm_updates_available: "Atualizações disponíveis!"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/pt.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/pt.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language: "Português"
     ulm_currency: "€"
     ulm_updates_available: "Updates available!"
     ulm_no_updates_available: "No updates available"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/pt.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/pt.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language_code: "pt"
     ulm_language: "Português"
     ulm_currency: "€"
     ulm_updates_available: "Updates available!"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/ru.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/ru.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language_code: "ru"
     ulm_language: "Русский"
     ulm_currency: "RUB"
     ulm_updates_available: "Доступны обновления!"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/ru.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/ru.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language: "Русский"
     ulm_currency: "RUB"
     ulm_updates_available: "Доступны обновления!"
     ulm_no_updates_available: "Нет доступных обновлений"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/sk.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/sk.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language_code: "sk"
     ulm_language: "Slovenský"
     ulm_currency: "€"
     ulm_updates_available: "Aktualizácia k dispozícii!"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/sk.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/sk.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language: "Slovenský"
     ulm_currency: "€"
     ulm_updates_available: "Aktualizácia k dispozícii!"
     ulm_no_updates_available: "Nie je k dispozícii žiadna aktualizácia"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/sv.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/sv.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language_code: "sv"
     ulm_language: "Svenska"
     ulm_currency: "kr"
     ulm_updates_available: "Uppdatering tillgänglig!"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/sv.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/sv.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language: "Svenska"
     ulm_currency: "kr"
     ulm_updates_available: "Uppdatering tillgänglig!"
     ulm_no_updates_available: "Ingen uppdatering tillgänglig"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/tr.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/tr.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language_code: "tr"
     ulm_language: "Türk"
     ulm_currency: "TRY"
     ulm_updates_available: "Güncellemeler var!"

--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/tr.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/tr.yaml
@@ -1,6 +1,7 @@
 ---
 ulm_language_variables:
   variables:
+    ulm_language: "Türk"
     ulm_currency: "TRY"
     ulm_updates_available: "Güncellemeler var!"
     ulm_no_updates_available: "Güncelleme yok"


### PR DESCRIPTION
I added for each language a language field describing the language name in the language it's in.

*Why is this usefull?*
I found that custom_cards use the `ulm_language_variables` variable, but if there is more then one translation file present, Minimalist grabs the last file loaded in (in my case Turkish). This is a fix that enables bugs like #1094 to be fixed easier in my opinion.

So adding this *should* enable the opportunity to do logical checks like `if ulm_language == hass_language_variable` to determine the correct language.

This PR is blocked by #1098 or needs that PR pulled in first before merging. Let me know what the accepted approach is (don't want to steal the credits from @ulug79)

Note: please review the language names as my mother language is Dutch and I used Google Translate to translate the names