### PR TITLE
custom_card_paddy_waste_collection- fixed broken variables to point to entity

### DIFF
--- a/custom_cards/custom_card_paddy_waste_collection/README.md
+++ b/custom_cards/custom_card_paddy_waste_collection/README.md
@@ -25,6 +25,11 @@ Initial release
 <summary>1.0.1</summary>
 Fix for UI Minimalist v1.0.1.
 </details>
+<details>
+<summary>1.0.2</summary>
+Fixed the bug where card doesn't show at all
+</details>
+
 
 ## Usage
 
@@ -67,12 +72,12 @@ This card needs the following to function correctly:
 <td>yes</td>
 <td>Your waste collection sensor. See <a href="#homeassistant">HA example</a> on how to configure.</td>
 </tr>
-<td>ulm_custom_card_paddy_waste_collection_name</td>
+<td>ulm_card_generic_swap_name</td>
 <td>Paper</td>
 <td>no</td>
 <td></td>
 </tr>
-<td>ulm_custom_card_paddy_waste_collection_icon</td>
+<td>ulm_card_generic_swap_icon</td>
 <td>mdi:trash-can</td>
 <td>no</td>
 <td></td>

--- a/custom_cards/custom_card_paddy_waste_collection/README.md
+++ b/custom_cards/custom_card_paddy_waste_collection/README.md
@@ -30,7 +30,6 @@ Fix for UI Minimalist v1.0.1.
 Fixed the bug where card doesn't show at all
 </details>
 
-
 ## Usage
 
 ```yaml

--- a/custom_cards/custom_card_paddy_waste_collection/custom_card_paddy_waste_collection.yaml
+++ b/custom_cards/custom_card_paddy_waste_collection/custom_card_paddy_waste_collection.yaml
@@ -3,8 +3,8 @@ custom_card_paddy_waste_collection:
   template:
     - "card_generic_swap"
   variables:
-    ulm_card_generic_swap_name: "[[[ return variables.ulm_custom_card_paddy_waste_collection_name; ]]]"
-    ulm_card_generic_swap_icon: "[[[ return variables.ulm_custom_card_paddy_waste_collection_icon; ]]]"
+    ulm_card_generic_swap_name: "[[[ return entity.name; ]]]"
+    ulm_card_generic_swap_icon: "[[[ return entity.icon; ]]]"
   state:
     - operator: "template"
       value: "[[[ return states[entity.entity_id].attributes.daysTo == 0; ]]]"


### PR DESCRIPTION
The custom card was broken as per:
https://github.com/UI-Lovelace-Minimalist/UI/pull/783

Fixed this by setting the variable to the entity.