### PR TITLE
Media Player Card Volume Buttons

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_media_player.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_media_player.yaml
@@ -49,7 +49,7 @@ card_media_player:
             }
             if (variables.ulm_card_media_player_enable_volume_buttons){
               rows = rows + " min-content";
-            }           
+            }
             return rows;
           ]]]
       - row-gap: |-
@@ -136,7 +136,7 @@ card_media_player:
                   ? 'white'
                   : 'rgba(var(--color-theme), 0.9)'
                 ]]]
-    item1: # Entity Button
+    item1:
       card:
         type: "custom:button-card"
         custom_fields:
@@ -273,7 +273,7 @@ card_media_player:
                   - background: "none"
                   - border-radius: "0"
                   - box-shadow: "none"
-    item2: # Controls
+    item2:
       card:
         type: "custom:button-card"
         template: "list_4_items"
@@ -480,7 +480,7 @@ card_media_player:
                       type: "custom:button-card"
                       template: "popup_media_player_source_card"
                       entity: "[[[ return entity.entity_id; ]]]"
-    item3: # Volume Slider
+    item3:
       card:
         type: "custom:my-slider"
         entity: "[[[ return entity.entity_id ]]]"
@@ -510,7 +510,7 @@ card_media_player:
             background-color: transparent;
             box-shadow: none;
           }
-      item4: # Volume Control Buttons
+      item4:
         card:
           type: "custom:button-card"
           template: "list_3_items"

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_media_player.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_media_player.yaml
@@ -10,6 +10,8 @@ card_media_player:
     ulm_card_media_player_enable_art: false
     ulm_card_media_player_enable_controls: false
     ulm_card_media_player_enable_volume_slider: false
+    ulm_card_media_player_enable_volume_buttons: false
+    ulm_card_media_player_enable_volume_adjust: false
     ulm_card_media_player_collapsible: false
     ulm_card_media_player_player_controls_entity: "[[[ return entity.entity_id ]]]"
     ulm_card_media_player_enable_popup: false
@@ -30,6 +32,9 @@ card_media_player:
             if (variables.ulm_card_media_player_enable_volume_slider){
               areas = areas + " 'item3'";
             }
+            if (variables.ulm_card_media_player_enable_volume_buttons){
+              areas = areas + " 'item4'";
+            }
             return areas;
           ]]]
       - grid-template-columns: "1fr"
@@ -42,6 +47,9 @@ card_media_player:
             if (variables.ulm_card_media_player_enable_volume_slider){
               rows = rows + " min-content";
             }
+            if (variables.ulm_card_media_player_enable_volume_buttons){
+              rows = rows + " min-content";
+            }           
             return rows;
           ]]]
       - row-gap: |-
@@ -90,6 +98,17 @@ card_media_player:
               }
               return "none";
             ]]]
+      item4:
+        - display: |
+            [[[
+              if(variables.ulm_card_media_player_enable_volume_buttons) {
+                if(variables.ulm_card_media_player_collapsible){
+                return (entity.state === "off" || entity.state === "standby") ? "none" : "block";
+                }
+                return "block";
+              }
+              return "none";
+            ]]]
   custom_fields:
     power:
       card:
@@ -117,7 +136,7 @@ card_media_player:
                   ? 'white'
                   : 'rgba(var(--color-theme), 0.9)'
                 ]]]
-    item1:
+    item1: # Entity Button
       card:
         type: "custom:button-card"
         custom_fields:
@@ -254,7 +273,7 @@ card_media_player:
                   - background: "none"
                   - border-radius: "0"
                   - box-shadow: "none"
-    item2:
+    item2: # Controls
       card:
         type: "custom:button-card"
         template: "list_4_items"
@@ -330,6 +349,8 @@ card_media_player:
                   entity_id: "[[[ return variables.ulm_card_media_player_player_controls_entity ]]]"
               icon: "[[[ return (entity.attributes?.media_duration > 0) ? 'mdi:pause' : 'mdi:stop' ]]]"
               state:
+                - value: "playing"
+                  icon: "mdi:pause"
                 - value: "paused"
                   icon: "mdi:play"
                 - value: "off"
@@ -459,7 +480,7 @@ card_media_player:
                       type: "custom:button-card"
                       template: "popup_media_player_source_card"
                       entity: "[[[ return entity.entity_id; ]]]"
-    item3:
+    item3: # Volume Slider
       card:
         type: "custom:my-slider"
         entity: "[[[ return entity.entity_id ]]]"
@@ -489,3 +510,175 @@ card_media_player:
             background-color: transparent;
             box-shadow: none;
           }
+      item4: # Volume Control Buttons
+        card:
+          type: "custom:button-card"
+          template: "list_3_items"
+          styles:
+            card:
+              - padding: "0px"
+              - background: "none"
+              - border-radius: "0"
+              - box-shadow: "none"
+          custom_fields:
+            item1:
+              card:
+                type: "custom:button-card"
+                template: "widget_icon"
+                entity: "[[[ return variables.ulm_card_media_player_player_controls_entity ]]]"
+                hold_action:
+                  action: >
+                    [[[
+                        return variables.ulm_card_media_player_enable_popup ? "fire-dom-event" : "more-info";
+                    ]]]
+                  browser_mod:
+                    service: "browser_mod.popup"
+                    data:
+                      large: true
+                      hide_header: true
+                      content:
+                        type: "custom:button-card"
+                        template: "popup_media_player_infos"
+                        entity: "[[[ return entity.entity_id; ]]]"
+                tap_action:
+                  action: "call-service"
+                  service: "media_player.volume_mute"
+                  service_data:
+                    entity_id: "[[[ return variables.ulm_card_media_player_player_controls_entity ]]]"
+                    is_volume_muted: "[[[ return (states[entity.entity_id].attributes.is_volume_muted) ? false : true; ]]]"
+                icon: "mdi:volume-mute"
+                styles:
+                  card:
+                    - background-color: |
+                        [[[
+                          return variables.ulm_card_media_player_enable_art && states[entity.entity_id].attributes.entity_picture != null
+                          ? 'rgba(0, 0, 0, 0.2)'
+                          : 'rgba(var(--color-theme),0.05)'
+                        ]]]
+                  icon:
+                    - color: |
+                        [[[
+                          return variables.ulm_card_media_player_enable_art && states[entity.entity_id].attributes.entity_picture != null
+                          ? 'white'
+                          : 'rgba(var(--color-theme), 0.9)'
+                        ]]]
+            item2:
+              card:
+                type: "custom:button-card"
+                template: "widget_icon"
+                entity: "[[[ return variables.ulm_card_media_player_player_controls_entity ]]]"
+                hold_action:
+                  action: >
+                    [[[
+                        return variables.ulm_card_media_player_enable_popup ? "fire-dom-event" : "more-info";
+                    ]]]
+                  browser_mod:
+                    service: "browser_mod.popup"
+                    data:
+                      large: true
+                      hide_header: true
+                      content:
+                        type: "custom:button-card"
+                        template: "popup_media_player_infos"
+                        entity: "[[[ return entity.entity_id; ]]]"
+                tap_action:
+                  action: "call-service"
+                  service: "media_player.volume_set"
+                  service_data:
+                    entity_id: "[[[ return variables.ulm_card_media_player_player_controls_entity ]]]"
+                    volume_level: |
+                      [[[
+                        var volume = states[entity.entity_id].attributes.volume_level;
+                        if (ulm_card_media_player_enable_volume_adjust) {
+                            volume = states[entity.entity_id].attributes.volume_level + ulm_card_media_player_enable_volume_adjust;
+                        } else {
+                            if (states[entity.entity_id].attributes.device_class === "tv") {
+                                volume = states[entity.entity_id].attributes.volume_level - 0.01;
+                            }
+                            if (states[entity.entity_id].attributes.device_class === "speaker") {
+                                volume = states[entity.entity_id].attributes.volume_level - 0.05;
+                            }
+                            if (states[entity.entity_id].attributes.device_class === "receiver") {
+                                volume = states[entity.entity_id].attributes.volume_level - 0.025;
+                            } else {
+                                volume = states[entity.entity_id].attributes.volume_level - 0.025;
+                            }
+                        }
+                        return volume;
+                      ]]]
+                icon: "mdi:volume-minus"
+                styles:
+                  card:
+                    - background-color: |
+                        [[[
+                          return variables.ulm_card_media_player_enable_art && states[entity.entity_id].attributes.entity_picture != null
+                          ? 'rgba(0, 0, 0, 0.2)'
+                          : 'rgba(var(--color-theme),0.05)'
+                        ]]]
+                  icon:
+                    - color: |
+                        [[[
+                          return variables.ulm_card_media_player_enable_art && states[entity.entity_id].attributes.entity_picture != null
+                          ? 'white'
+                          : 'rgba(var(--color-theme), 0.9)'
+                        ]]]
+            item3:
+              card:
+                type: "custom:button-card"
+                template: "widget_icon"
+                entity: "[[[ return variables.ulm_card_media_player_player_controls_entity ]]]"
+                hold_action:
+                  action: >
+                    [[[
+                        return variables.ulm_card_media_player_enable_popup ? "fire-dom-event" : "more-info";
+                    ]]]
+                  browser_mod:
+                    service: "browser_mod.popup"
+                    data:
+                      large: true
+                      hide_header: true
+                      content:
+                        type: "custom:button-card"
+                        template: "popup_media_player_infos"
+                        entity: "[[[ return entity.entity_id; ]]]"
+                tap_action:
+                  action: "call-service"
+                  service: "media_player.volume_set"
+                  service_data:
+                    entity_id: "[[[ return variables.ulm_card_media_player_player_controls_entity ]]]"
+                    volume_level: |
+                      [[[
+                        var volume = states[entity.entity_id].attributes.volume_level;
+                        if (ulm_card_media_player_enable_volume_adjust) {
+                            volume = states[entity.entity_id].attributes.volume_level + ulm_card_media_player_enable_volume_adjust;
+                        } else {
+                            if (states[entity.entity_id].attributes.device_class === "tv") {
+                                volume = states[entity.entity_id].attributes.volume_level + 0.01;
+                            }
+                            if (states[entity.entity_id].attributes.device_class === "speaker") {
+                                volume = states[entity.entity_id].attributes.volume_level + 0.05;
+                            }
+                            if (states[entity.entity_id].attributes.device_class === "receiver") {
+                                volume = states[entity.entity_id].attributes.volume_level + 0.025;
+                            } else {
+                                volume = states[entity.entity_id].attributes.volume_level + 0.025;
+                            }
+                        }
+                        return volume;
+                      ]]]
+                icon: "mdi:volume-plus"
+                styles:
+                  card:
+                    - background-color: |
+                        [[[
+                          return variables.ulm_card_media_player_enable_art && states[entity.entity_id].attributes.entity_picture != null
+                          ? 'rgba(0, 0, 0, 0.2)'
+                          : 'rgba(var(--color-theme),0.05)'
+                        ]]]
+                  icon:
+                    - color: |
+                        [[[
+                          return variables.ulm_card_media_player_enable_art && states[entity.entity_id].attributes.entity_picture != null
+                          ? 'white'
+                          : 'rgba(var(--color-theme), 0.9)'
+                        ]]]

--- a/docs/usage/cards/card_media_player.md
+++ b/docs/usage/cards/card_media_player.md
@@ -27,6 +27,8 @@ hide:
 | ulm_card_media_player_enable_art             | false   |                  | Enable album picture on background              |
 | ulm_card_media_player_enable_controls        | false   |                  | Enable controls below the title                 |
 | ulm_card_media_player_enable_volume_slider   | false   |                  | Enable volume slider below controls             |
+| ulm_card_media_player_enable_volume_buttons  | false   |                  | Enable volume buttons below controls            |
+| ulm_card_media_player_enable_volume_buttons  | 5       |                  | Volume Adjust Amount - if not set then 1 for TV and 5 for Speaker |
 | ulm_card_media_player_collapsible            | false   |                  | Controls are collapsible when state is off      |
 | ulm_card_media_player_player_controls_entity | entity  |                  | Change the controlled entity                    |
 | ulm_card_media_player_enable_popup           | false   |                  | Enable pop-up                                   |


### PR DESCRIPTION
Added a new row to use Volume Buttons (Mute, Up and Down) to the Card.
Can be as well as or instead of the Slider, just an additional row.

Majority of this work is taken from #1042 so big thanks to @antonio1475 for that. I have not implemented all of his updates a I've tried to keep the card as similar as possible to the previous version.
Included:
- Volume Buttons
- Toggle Mute
- Volume Adjust Amount (1% for TV, 5% for Speaker, 2.5% Receiver or Default)