### PR TITLE
custom_bar_card Icon Choice

### DIFF
--- a/custom_cards/custom_card_bar_card/README.md
+++ b/custom_cards/custom_card_bar_card/README.md
@@ -78,6 +78,13 @@ This card needs the following to function correctly:
 <td>Overwrites the sensor name</td>
 </tr>
 <tr>
+<td>ulm_custom_card_bar_card_icon</td>
+<td>"mdi:icon"</td>
+<td>no</td>
+<td>Sensor Icon</td>
+<td>Overwrites the sensor icon</td>
+</tr>
+<tr>
 <td>ulm_custom_card_bar_card_value</td>
 <td>true / false</td>
 <td>no</td>

--- a/custom_cards/custom_card_bar_card/custom_card_bar_card.yaml
+++ b/custom_cards/custom_card_bar_card/custom_card_bar_card.yaml
@@ -22,6 +22,7 @@ custom_card_bar_card:
           - "card_generic"
         variables:
           ulm_card_generic_name: "[[[ return variables.ulm_custom_card_bar_card_name != '' ? variables.ulm_custom_card_bar_card_name : '' ]]]"
+          ulm_card_generic_icon: "[[[ return variables.ulm_custom_card_bar_card_icon != '' ? variables.ulm_custom_card_bar_card_icon : '' ]]]"
         styles:
           card:
             - box-shadow: "none"


### PR DESCRIPTION
Simple fix to allow icon to be overwritten for custom_bar_card

(Apologies for numerous PRs... have kept separate for each card but might not be the preferred option)