### PR TITLE
Fix error in custom_card_nas example

### DIFF
--- a/docs/usage/custom_cards/custom_card_nas.md
+++ b/docs/usage/custom_cards/custom_card_nas.md
@@ -37,7 +37,7 @@ Fix card & add Screenshot
   variables:
     ulm_custom_card_nas_sensor: sensor.pinas_disk_use
     ulm_custom_card_nas_text: "HDD used"
-    ulm_custom_cad_nas_unit: %
+    ulm_custom_card_nas_unit: "%"
 ```
 
 ## Requirements
@@ -69,7 +69,7 @@ n/a
 <td>ulm_custom_card_nas_unit</td>
 <td>%</td>
 <td>yes</td>
-<td>The unit to show after your sensors state</td>
+  <td>The unit to show after your sensors state (use empty string to show nothing eg. "")</td>
 </tr>
 </table>
 


### PR DESCRIPTION
This fixes some errors/typos for the custom_card_nas examples, so that it can be copied and pasted without receiving any errors.

I also added some additional information to use an empty string as unit in order to show nothing, since stating nothing would otherwise give back _undefined_ or _null_.