### PR TITLE
Add custom weather data support to Weather Card

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_weather.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_weather.yaml
@@ -29,6 +29,7 @@ card_weather:
         primary_info: "[[[ return variables.ulm_card_weather_primary_info ]]]"
         secondary_info: "[[[ return variables.ulm_card_weather_secondary_info ]]]"
         backdrop: "[[[ return variables.ulm_card_weather_backdrop ]]]"
+        custom: "[[[ return variables.ulm_card_weather_custom ]]]"
         style: |
           ha-card {
             border-radius: 14px;

--- a/docs/usage/cards/card_weather.md
+++ b/docs/usage/cards/card_weather.md
@@ -22,7 +22,7 @@ This is a card based on simple-weather-card to show your weather.
 | ulm_card_weather_primary_info | `extrema`   |                  | customize primary info. Set to `false` to disable. See [simple-weather-card](https://github.com/kalkih/simple-weather-card) for more information |
 | ulm_card_weather_secondary_info | `precipitation`   |          | customize secondary info. Set to `false` to disable. See [simple-weather-card](https://github.com/kalkih/simple-weather-card) for more information |
 | ulm_card_weather_backdrop | `false`         |                  | add backdrop. See [simple-weather-card](https://github.com/kalkih/simple-weather-card) for more information |
-| ulm_card_weather_custom | | | customize weather data. See [simple-weather-card](https://github.com/kalkih/simple-weather-card#custom-option-array)
+| ulm_card_weather_custom | | | customize weather data. See [simple-weather-card](https://github.com/kalkih/simple-weather-card#custom-option-array) |
 
 ## Usage
 

--- a/docs/usage/cards/card_weather.md
+++ b/docs/usage/cards/card_weather.md
@@ -22,6 +22,7 @@ This is a card based on simple-weather-card to show your weather.
 | ulm_card_weather_primary_info | `extrema`   |                  | customize primary info. Set to `false` to disable. See [simple-weather-card](https://github.com/kalkih/simple-weather-card) for more information |
 | ulm_card_weather_secondary_info | `precipitation`   |          | customize secondary info. Set to `false` to disable. See [simple-weather-card](https://github.com/kalkih/simple-weather-card) for more information |
 | ulm_card_weather_backdrop | `false`         |                  | add backdrop. See [simple-weather-card](https://github.com/kalkih/simple-weather-card) for more information |
+| ulm_card_weather_custom | | | customize weather data. See [simple-weather-card](https://github.com/kalkih/simple-weather-card#custom-option-array)
 
 ## Usage
 
@@ -36,6 +37,8 @@ This is a card based on simple-weather-card to show your weather.
       - precipitation_probability
     ulm_card_weather_backdrop:
       fade: true
+    ulm_card_weather_custom:
+      - temp: sensor.temperature
 ```
 
 ??? note "Template Code"


### PR DESCRIPTION
This PR adds the ability to customize the weather data shown on the standard Weather Card in UI-Lovelace-Minimalist.

It exposes the existing underlying `custom` capability of simple-weather-card as variable `ulm_card_weather_custom` using a simple one line addition to the `card_weather.yaml` file.

The PR includes an update of the documentation to show a usage example.