### PR TITLE
Card_light Rework color background

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_light.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_light.yaml
@@ -275,32 +275,25 @@ card_light:
                 card:
                   - background-color: >
                       [[[
-                        if (!hass.themes.darkMode) {
-                          var color_set = variables.ulm_card_light_enable_color ? entity.attributes.rgb_color : variables.ulm_card_light_color;
-                          var color = 'rgba(var(--color-' + color_set + '),0.2)'
-                          if (variables.ulm_card_light_enable_color) {
+                        if (!hass.themes.darkMode && variables.ulm_card_light_force_background_color) {
+                          if (variables.ulm_card_light_enable_color && entity.state != "off") {
                             return 'rgba(250, 250, 250,0.8)';
                           }
-                          if (entity.state != "on") {
-                            return 'rgba(var(--color-theme),0.05)';
-                          }
-                          return color
                         }
                         return 'rgba(var(--color-theme),0.05)';
                       ]]]
                 icon:
                   - color: >
                       [[[
-                        if (!hass.themes.darkMode) {
-                          var color_set = variables.ulm_card_light_enable_color ? entity.attributes.rgb_color : variables.ulm_card_light_color;
-                          var color = 'rgba(var(--color-' + color_set + '),1)';
-                          if (variables.ulm_card_light_enable_color) {
-                            color = 'rgba(' + color_set + ',1)';
+                        if (!hass.themes.darkMode && variables.ulm_card_light_force_background_color) {
+                          if (entity.state != "off") {
+                            var color_set = variables.ulm_card_light_enable_color ? entity.attributes.rgb_color : variables.ulm_card_light_color;
+                            var color = 'rgba(var(--color-' + color_set + '),1)';
+                            if (variables.ulm_card_light_enable_color) {
+                              color = 'rgba(' + color_set + ',1)';
+                            }
+                            return color;
                           }
-                          if (entity.state != "on") {
-                            return 'rgba(var(--color-theme),0.2)';
-                          }
-                          return color;
                         }
                         return 'rgba(var(--color-theme),0.9)';
                       ]]]
@@ -319,32 +312,25 @@ card_light:
                 card:
                   - background-color: >
                       [[[
-                        if (!hass.themes.darkMode) {
-                          var color_set = variables.ulm_card_light_enable_color ? entity.attributes.rgb_color : variables.ulm_card_light_color;
-                          var color = 'rgba(var(--color-' + color_set + '),0.2)'
-                          if (variables.ulm_card_light_enable_color) {
+                        if (!hass.themes.darkMode && variables.ulm_card_light_force_background_color) {
+                          if (variables.ulm_card_light_enable_color && entity.state != "off") {
                             return 'rgba(250, 250, 250,0.8)';
                           }
-                          if (entity.state != "on") {
-                            return 'rgba(var(--color-theme),0.05)';
-                          }
-                          return color
                         }
                         return 'rgba(var(--color-theme),0.05)';
                       ]]]
                 icon:
                   - color: >
                       [[[
-                        if (!hass.themes.darkMode) {
-                          var color_set = variables.ulm_card_light_enable_color ? entity.attributes.rgb_color : variables.ulm_card_light_color;
-                          var color = 'rgba(var(--color-' + color_set + '),1)';
-                          if (variables.ulm_card_light_enable_color) {
-                            color = 'rgba(' + color_set + ',1)';
+                        if (!hass.themes.darkMode && variables.ulm_card_light_force_background_color) {
+                          if (entity.state != "off") {
+                            var color_set = variables.ulm_card_light_enable_color ? entity.attributes.rgb_color : variables.ulm_card_light_color;
+                            var color = 'rgba(var(--color-' + color_set + '),1)';
+                            if (variables.ulm_card_light_enable_color) {
+                              color = 'rgba(' + color_set + ',1)';
+                            }
+                            return color;
                           }
-                          if (entity.state != "on") {
-                            return 'rgba(var(--color-theme),0.2)';
-                          }
-                          return color;
                         }
                         return 'rgba(var(--color-theme),0.9)';
                       ]]]
@@ -363,32 +349,25 @@ card_light:
                 card:
                   - background-color: >
                       [[[
-                        if (!hass.themes.darkMode) {
-                          var color_set = variables.ulm_card_light_enable_color ? entity.attributes.rgb_color : variables.ulm_card_light_color;
-                          var color = 'rgba(var(--color-' + color_set + '),0.2)'
-                          if (variables.ulm_card_light_enable_color) {
+                        if (!hass.themes.darkMode && variables.ulm_card_light_force_background_color) {
+                          if (variables.ulm_card_light_enable_color && entity.state != "off") {
                             return 'rgba(250, 250, 250,0.8)';
                           }
-                          if (entity.state != "on") {
-                            return 'rgba(var(--color-theme),0.05)';
-                          }
-                          return color
                         }
                         return 'rgba(var(--color-theme),0.05)';
                       ]]]
                 icon:
                   - color: >
                       [[[
-                        if (!hass.themes.darkMode) {
-                          var color_set = variables.ulm_card_light_enable_color ? entity.attributes.rgb_color : variables.ulm_card_light_color;
-                          var color = 'rgba(var(--color-' + color_set + '),1)';
-                          if (variables.ulm_card_light_enable_color) {
-                            color = 'rgba(' + color_set + ',1)';
+                        if (!hass.themes.darkMode && variables.ulm_card_light_force_background_color) {
+                          if (entity.state != "off") {
+                            var color_set = variables.ulm_card_light_enable_color ? entity.attributes.rgb_color : variables.ulm_card_light_color;
+                            var color = 'rgba(var(--color-' + color_set + '),1)';
+                            if (variables.ulm_card_light_enable_color) {
+                              color = 'rgba(' + color_set + ',1)';
+                            }
+                            return color;
                           }
-                          if (entity.state != "on") {
-                            return 'rgba(var(--color-theme),0.2)';
-                          }
-                          return color;
                         }
                         return 'rgba(var(--color-theme),0.9)';
                       ]]]

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_light.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_light.yaml
@@ -270,6 +270,40 @@ card_light:
             card:
               type: "custom:button-card"
               template: "widget_icon"
+              entity: "[[[ return entity.entity_id ]]]"
+              styles:
+                card:
+                  - background-color: >
+                      [[[
+                        if (!hass.themes.darkMode) {
+                          var color_set = variables.ulm_card_light_enable_color ? entity.attributes.rgb_color : variables.ulm_card_light_color;
+                          var color = 'rgba(var(--color-' + color_set + '),0.2)'
+                          if (variables.ulm_card_light_enable_color) {
+                            return 'rgba(250, 250, 250,0.8)';
+                          }
+                          if (entity.state != "on") {
+                            return 'rgba(var(--color-theme),0.05)';
+                          }
+                          return color
+                        }
+                        return 'rgba(var(--color-theme),0.05)';
+                      ]]]
+                icon:
+                  - color: >
+                      [[[
+                        if (!hass.themes.darkMode) {
+                          var color_set = variables.ulm_card_light_enable_color ? entity.attributes.rgb_color : variables.ulm_card_light_color;
+                          var color = 'rgba(var(--color-' + color_set + '),1)';
+                          if (variables.ulm_card_light_enable_color) {
+                            color = 'rgba(' + color_set + ',1)';
+                          }
+                          if (entity.state != "on") {
+                            return 'rgba(var(--color-theme),0.2)';
+                          }
+                          return color;
+                        }
+                        return 'rgba(var(--color-theme),0.9)';
+                      ]]]
               tap_action:
                 action: "call-service"
                 service: "light.turn_on"
@@ -281,6 +315,39 @@ card_light:
             card:
               type: "custom:button-card"
               template: "widget_icon"
+              styles:
+                card:
+                  - background-color: >
+                      [[[
+                        if (!hass.themes.darkMode) {
+                          var color_set = variables.ulm_card_light_enable_color ? entity.attributes.rgb_color : variables.ulm_card_light_color;
+                          var color = 'rgba(var(--color-' + color_set + '),0.2)'
+                          if (variables.ulm_card_light_enable_color) {
+                            return 'rgba(250, 250, 250,0.8)';
+                          }
+                          if (entity.state != "on") {
+                            return 'rgba(var(--color-theme),0.05)';
+                          }
+                          return color
+                        }
+                        return 'rgba(var(--color-theme),0.05)';
+                      ]]]
+                icon:
+                  - color: >
+                      [[[
+                        if (!hass.themes.darkMode) {
+                          var color_set = variables.ulm_card_light_enable_color ? entity.attributes.rgb_color : variables.ulm_card_light_color;
+                          var color = 'rgba(var(--color-' + color_set + '),1)';
+                          if (variables.ulm_card_light_enable_color) {
+                            color = 'rgba(' + color_set + ',1)';
+                          }
+                          if (entity.state != "on") {
+                            return 'rgba(var(--color-theme),0.2)';
+                          }
+                          return color;
+                        }
+                        return 'rgba(var(--color-theme),0.9)';
+                      ]]]
               tap_action:
                 action: "call-service"
                 service: "light.turn_on"
@@ -292,6 +359,39 @@ card_light:
             card:
               type: "custom:button-card"
               template: "widget_icon"
+              styles:
+                card:
+                  - background-color: >
+                      [[[
+                        if (!hass.themes.darkMode) {
+                          var color_set = variables.ulm_card_light_enable_color ? entity.attributes.rgb_color : variables.ulm_card_light_color;
+                          var color = 'rgba(var(--color-' + color_set + '),0.2)'
+                          if (variables.ulm_card_light_enable_color) {
+                            return 'rgba(250, 250, 250,0.8)';
+                          }
+                          if (entity.state != "on") {
+                            return 'rgba(var(--color-theme),0.05)';
+                          }
+                          return color
+                        }
+                        return 'rgba(var(--color-theme),0.05)';
+                      ]]]
+                icon:
+                  - color: >
+                      [[[
+                        if (!hass.themes.darkMode) {
+                          var color_set = variables.ulm_card_light_enable_color ? entity.attributes.rgb_color : variables.ulm_card_light_color;
+                          var color = 'rgba(var(--color-' + color_set + '),1)';
+                          if (variables.ulm_card_light_enable_color) {
+                            color = 'rgba(' + color_set + ',1)';
+                          }
+                          if (entity.state != "on") {
+                            return 'rgba(var(--color-theme),0.2)';
+                          }
+                          return color;
+                        }
+                        return 'rgba(var(--color-theme),0.9)';
+                      ]]]
               tap_action:
                 action: "call-service"
                 service: "light.turn_on"

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_light.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_light.yaml
@@ -12,6 +12,7 @@ card_light:
     ulm_card_light_enable_horizontal_wide: false
     ulm_card_light_enable_color: false
     ulm_card_light_color_palette: ""
+    ulm_card_light_color: "yellow"
     ulm_card_light_force_background_color: false
     ulm_card_light_enable_slider: false
     ulm_card_light_enable_slider_minSet: 0
@@ -31,16 +32,14 @@ card_light:
         card:
           - background-color: >
               [[[
-                  var color = entity.attributes.rgb_color;
-                  if (variables.ulm_card_light_enable_color) {
-                    if (variables.ulm_card_light_force_background_color || hass.themes.darkMode) {
-                      if (color) {
-                        return 'rgba(' + color + ',0.1)';
-                      } else {
-                        return 'rgba(var(--color-yellow),0.1)';
-                      }
-                    }
-                  }
+                var color_set = variables.ulm_card_light_enable_color ? entity.attributes.rgb_color : variables.ulm_card_light_color;
+                var color = 'rgba(var(--color-' + color_set + '),var(--opacity-bg))'
+                if(variables.ulm_card_light_enable_color){
+                  color = 'rgba(' + color_set + ',var(--opacity-bg))'
+                }
+                if (variables.ulm_card_light_force_background_color || hass.themes.darkMode) {
+                  return color
+                }
               ]]]
   styles:
     grid:
@@ -150,28 +149,28 @@ card_light:
                 icon:
                   - color: >
                       [[[
-                          var color = entity.attributes.rgb_color;
-                          if (entity.state != "on") {
-                            return 'rgba(var(--color-theme),0.2)';
-                          }
-                          else if (color && variables.ulm_card_light_enable_color) {
-                            return 'rgba(' + color + ',1)'
-                          } else {
-                            return 'rgba(var(--color-yellow),1)'
-                          }
+                        var color_set = variables.ulm_card_light_enable_color ? entity.attributes.rgb_color : variables.ulm_card_light_color;
+                        var color = 'rgba(var(--color-' + color_set + '),1)'
+                        if(variables.ulm_card_light_enable_color){
+                          color = 'rgba(' + color_set + ',1)'
+                        }
+                        if (entity.state != "on") {
+                          return 'rgba(var(--color-theme),0.2)';
+                        }
+                        return color
                       ]]]
                 img_cell:
                   - background-color: >
                       [[[
-                          var color = entity.attributes.rgb_color;
-                          if (entity.state != "on") {
-                            return 'rgba(var(--color-theme),0.05)';
-                          }
-                          else if (color && variables.ulm_card_light_enable_color) {
-                            return 'rgba(' + color + ',0.2)';
-                          } else {
-                            return 'rgba(var(--color-yellow),0.2)';
-                          }
+                        var color_set = variables.ulm_card_light_enable_color ? entity.attributes.rgb_color : variables.ulm_card_light_color;
+                        var color = 'rgba(var(--color-' + color_set + '),0.2)'
+                        if(variables.ulm_card_light_enable_color){
+                          color = 'rgba(' + color_set + ',0.2)'
+                        }
+                        if (entity.state != "on") {
+                          return 'rgba(var(--color-theme),0.05)';
+                        }
+                        return color
                       ]]]
           item2:
             card:
@@ -204,32 +203,16 @@ card_light:
                     name:
                       - color: >
                           [[[
-                              var color = entity.attributes.rgb_color;
-                              if (variables.ulm_card_light_enable_color) {
-                                if (variables.ulm_card_light_force_background_color || hass.themes.darkMode) {
-                                  if (color) {
-                                    return 'rgba(' + color + ',1)';
-                                  } else {
-                                    return 'rgba(var(--color-yellow-text),1)';
-                                  }
-                                }
-                              }
-                              return 'rgba(var(--color-yellow-text),1)';
+                            if (variables.ulm_card_light_force_background_color) {
+                              return 'rgb(250,250,250)';
+                            }
                           ]]]
                     label:
                       - color: >
                           [[[
-                              var color = entity.attributes.rgb_color;
-                              if (variables.ulm_card_light_enable_color) {
-                                if (variables.ulm_card_light_force_background_color || hass.themes.darkMode) {
-                                  if (color) {
-                                    return 'rgba(' + color + ',1)';
-                                  } else {
-                                    return 'rgba(var(--color-yellow-text),1)';
-                                  }
-                                }
-                              }
-                              return 'rgba(var(--color-yellow-text),1)';
+                            if (variables.ulm_card_light_force_background_color) {
+                              return 'rgb(250,250,250)';
+                            }
                           ]]]
     item2:
       card:
@@ -241,39 +224,45 @@ card_light:
         maxSet: "[[[ return variables.ulm_card_light_enable_slider_maxSet ]]]"
         mainSliderColor: >
           [[[
-              var color = entity.attributes.rgb_color;
-              if (entity.state == "unavailable") {
-                  return "rgba(var(--color-grey),1)";
-              }
-              else if (color && variables.ulm_card_light_enable_color) {
-                  return "rgba(" + color + ",1)";
-              } else {
-                  return "rgba(var(--color-yellow),1)";
-              }
+            var color_set = variables.ulm_card_light_enable_color ? entity.attributes.rgb_color : variables.ulm_card_light_color;
+            var color = 'rgba(var(--color-' + color_set + '),1)'
+            if(variables.ulm_card_light_enable_color){
+              color = 'rgba(' + color_set + ',1)'
+            }
+            if (entity.state == "unavailable") {
+              return "rgba(var(--color-grey),1)";
+            }
+            if(variables.ulm_card_light_force_background_color && !hass.themes.darkMode){
+              return 'rgba(250,250,250,1)'
+            }
+            return color
           ]]]
         secondarySliderColor: >
           [[[
-              var color = entity.attributes.rgb_color;
-              if (entity.state == "unavailable") {
-                  return "rgba(var(--color-grey),0.2)";
-              }
-              else if (color && variables.ulm_card_light_enable_color) {
-                  return "rgba(" + color + ",0.2)";
-              } else {
-                  return "rgba(var(--color-yellow),0.2)";
-              }
+            var color_set = variables.ulm_card_light_enable_color ? entity.attributes.rgb_color : variables.ulm_card_light_color;
+            var color = 'rgba(var(--color-' + color_set + '),0.2)'
+            if(variables.ulm_card_light_enable_color){
+              color = 'rgba(' + color_set + ',0.2)'
+            }
+            if (entity.state == "unavailable") {
+              return "rgba(var(--color-grey),0.2)";
+            }
+            return color
           ]]]
         thumbColor: >
           [[[
-              var color = entity.attributes.rgb_color;
-              if (entity.state == "unavailable") {
-                  return "rgba(var(--color-grey),1)";
-              }
-              else if (color && variables.ulm_card_light_enable_color) {
-                  return "rgba(" + color + ",1)";
-              } else {
-                  return "rgba(var(--color-yellow),1)";
-              }
+            var color_set = variables.ulm_card_light_enable_color ? entity.attributes.rgb_color : variables.ulm_card_light_color;
+            var color = 'rgba(var(--color-' + color_set + '),1)'
+            if(variables.ulm_card_light_enable_color){
+              color = 'rgba(' + color_set + ',1)'
+            }
+            if (entity.state == "unavailable") {
+              return "rgba(var(--color-grey),1)";
+            }
+            if(variables.ulm_card_light_force_background_color && !hass.themes.darkMode){
+              return 'rgba(250,250,250,1)'
+            }
+            return color
           ]]]
         mainSliderColorOff: "rgba(var(--color-theme),0.05)"
         secondarySliderColorOff: "rgba(var(--color-theme),0.05)"

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_light.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_light.yaml
@@ -197,23 +197,6 @@ card_light:
                   }
                   return label;
                 ]]]
-              state:
-                - value: "on"
-                  styles:
-                    name:
-                      - color: >
-                          [[[
-                            if (variables.ulm_card_light_force_background_color) {
-                              return 'rgb(250,250,250)';
-                            }
-                          ]]]
-                    label:
-                      - color: >
-                          [[[
-                            if (variables.ulm_card_light_force_background_color) {
-                              return 'rgb(250,250,250)';
-                            }
-                          ]]]
     item2:
       card:
         type: "custom:my-slider"

--- a/docs/usage/cards/card_light.md
+++ b/docs/usage/cards/card_light.md
@@ -44,7 +44,8 @@ To use `popup_light` you need to set the variable `ulm_card_light_enable_popup` 
 | ulm_card_light_enable_collapse        | `false`         | :material-close: | Collapse slider when off                               | Need `ulm_card_light_enable_slider: true`     |
 | ulm_card_light_enable_horizontal      | `false`         | :material-close: | Enable horizontal card                                 |                                               |
 | ulm_card_light_enable_horizontal_wide | `false`         | :material-close: | Wider slider                                           | Need `ulm_card_light_enable_horizontal: true` |
-| ulm_card_light_enable_color           | `false`         | :material-close: | Enable icon and label light color                      |                                               |
+| ulm_card_light_color           | `yellow`         | :material-close: | Set a manual color from the theme for icon, slider and background                      |                                               |
+| ulm_card_light_enable_color           | `false`         | :material-close: | Enable icon and label light color from the light itself.                       |  Overrides `ulm_card_light_color`                                             |
 | ulm_card_light_force_background_color | `false`         | :material-close: | Force background light color even in light theme       |                                               |
 | ulm_card_light_enable_popup           | `false`         | :material-close: | Enable `popup_light`                                   |                                               |
 | ulm_card_light_enable_popup_tap       | `false`         | :material-close: | Enable `popup_light` on simple icon tap                |                                               |


### PR DESCRIPTION
Make background colors more inline with examples found on behance

Example with `ulm_card_light_force_background_color: true`
<img width="1237" alt="image" src="https://user-images.githubusercontent.com/68892092/224312535-c3886585-d3ad-43b5-85ba-1e0c25eb5c4b.png">

Old behavior:
<img width="1233" alt="image" src="https://user-images.githubusercontent.com/68892092/224313090-d5575bad-42e6-4573-8ce6-c0c7a7163fcb.png">

- adds variable `ulm_card_light_color` to set manually the color when a light/switch is on

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [contribution guidelines](https://github.com/UI-Lovelace-Minimalist/UI/blob/main/.github/CONTRIBUTING.md)
    - [ ] This PR is for a custom-card or documentation change and therefore directed to the `main` branch.
    - [x] This PR is for a official card or any other directly to the integration related change and therefore directed to the `release` branch.
