### PR TITLE
Fixes #1260 - iOS tapbar covering content at the bottom

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-ios-tapbar/minimalist-ios-tapbar.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-ios-tapbar/minimalist-ios-tapbar.yaml
@@ -46,6 +46,8 @@ minimalist-ios-tapbar:
         margin: 0 !important;
         width: 100%;
         height: 100% !important;
+        margin-top: calc(-1 * var(--header-height)) !important;
+        padding-bottom: var(--header-height) !important;
       }
       .header {
         top: auto !important;

--- a/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-ios-tapbar/minimalist-ios-tapbar.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-ios-tapbar/minimalist-ios-tapbar.yaml
@@ -45,9 +45,6 @@ minimalist-ios-tapbar:
         position: fixed !important;
         margin: 0 !important;
         width: 100%;
-        height: 100% !important;
-        margin-top: calc(-1 * var(--header-height)) !important;
-        padding-bottom: var(--header-height) !important;
       }
       .header {
         top: auto !important;

--- a/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-mobile-tapbar/minimalist-mobile-tapbar.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-mobile-tapbar/minimalist-mobile-tapbar.yaml
@@ -39,7 +39,6 @@ minimalist-mobile-tapbar:
         position: fixed !important;
         margin: 0 !important;
         width: 100%;
-        height: 100% !important;
       }
       .header {
         top: auto !important;


### PR DESCRIPTION
This is the "safest" fix since I don't have much context of the code. Feel free to suggest a more appropriate fix.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #1260
- This PR is related to issue: #1260

Bottom content is now fully visible: 
<img width="243" alt="image" src="https://user-images.githubusercontent.com/2308950/231119132-cae72e6c-80c0-4646-8d17-099124f3df5f.png">

As well as content on the top: 
<img width="290" alt="image" src="https://user-images.githubusercontent.com/2308950/231119367-2b6de014-4797-4322-a2ed-1a0f40eddb78.png">



## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [contribution guidelines](https://github.com/UI-Lovelace-Minimalist/UI/blob/main/.github/CONTRIBUTING.md)
    - [ ] This PR is for a custom-card or documentation change and therefore directed to the `main` branch.
    - [ ] This PR is for a official card or any other directly to the integration related change and therefore directed to the `release` branch.
