### PR TITLE
[custom_template_shogun160_battery_info] fix visablity when force_bac…

### DIFF
--- a/custom_cards/custom_template_shogun160_battery_info/custom_template_shogun160_battery_info.yaml
+++ b/custom_cards/custom_template_shogun160_battery_info/custom_template_shogun160_battery_info.yaml
@@ -18,7 +18,7 @@ battery_info:
             const battery = Math.round((states[variables.ulm_battery_entity].state)/1);
             const radius = 20.5; const circumference = radius * 2 * Math.PI;
             return `<svg viewBox="0 0 50 50"><circle cx="25" cy="25" r="${radius}"
-            stroke="green" stroke-width="3" fill="none"
+            stroke="green" stroke-width="3" fill="var(--card-background-color)"
             style="transform: rotate(-90deg); transform-origin: 50% 50%;
             stroke-dasharray: ${circumference};
             stroke-dashoffset: ${circumference - battery / 100 * circumference};" />
@@ -29,7 +29,7 @@ battery_info:
             const battery = Math.round((entity.attributes.battery || entity.attributes.battery_level)/1);
             const radius = 20.5; const circumference = radius * 2 * Math.PI;
             return `<svg viewBox="0 0 50 50"><circle cx="25" cy="25" r="${radius}"
-            stroke="green" stroke-width="3" fill="none"
+            stroke="green" stroke-width="3" fill="var(--card-background-color)"
             style="transform: rotate(-90deg); transform-origin: 50% 50%;
             stroke-dasharray: ${circumference};
             stroke-dashoffset: ${circumference - battery / 100 * circumference};" />


### PR DESCRIPTION
…kground_color = true

Fill with var(--card-background-color) instead off none to make battery state readable when force_background_color = true

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [contribution guidelines](https://github.com/UI-Lovelace-Minimalist/UI/blob/main/.github/CONTRIBUTING.md)
    - [x] This PR is for a custom-card or documentation change and therefore directed to the `main` branch.
    - [ ] This PR is for a official card or any other directly to the integration related change and therefore directed to the `release` branch.
