### PR TITLE
Add ability to call script with custom fields/service_data to scene pills

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-mobile/minimalist-mobile.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-mobile/minimalist-mobile.yaml
@@ -20,7 +20,7 @@ minimalist-mobile:
     }
     #view {
       margin: 0 !important;
-      height: 100vh !important;
+      height: 100% !important;
     }
   card-mod-view-yaml: |
     "*:first-child$": |

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_welcome_scenes.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_welcome_scenes.yaml
@@ -297,6 +297,9 @@ card_scenes_pill_welcome:
               }
               else if(entity.entity_id.startsWith("input_select.")){
                 return "input_select.select_option"
+              }
+              else if(entity.entity_id.startsWith("script.")){
+                return entity.entity_id
               } else {
                 return "homeassistant.toggle"
               }
@@ -304,6 +307,9 @@ card_scenes_pill_welcome:
           navigation_path: "[[[ return variables?.nav_path; ]]]"
           service_data: |
             [[[
+              if (variables.service_data){
+                return variables.service_data
+              }
               var obj;
               if( entity.entity_id.startsWith("input_select.") )
                 obj = { entity_id: entity.entity_id, option: variables.state };
@@ -379,12 +385,18 @@ card_scenes_pill_welcome:
               }
               else if(entity.entity_id.startsWith("input_select.")){
                 return "input_select.select_option"
+              }
+              else if(entity.entity_id.startsWith("script.")){
+                return entity.entity_id
               } else {
                 return "homeassistant.toggle"
               }
             ]]]
           service_data: |
             [[[
+              if (variables.service_data){
+                return variables.service_data
+              }
               var obj;
               if( entity.entity_id.startsWith("input_select.") )
                 obj = { entity_id: entity.entity_id, option: variables.state };

--- a/docs/usage/cards/card_welcome_scenes.md
+++ b/docs/usage/cards/card_welcome_scenes.md
@@ -36,7 +36,7 @@ This is a card which shows the basic needs for your dashboard. This card can gen
 | _color  |  Random    | :material-close: | Color of the icon <br> Can choose between: `blue`, `red`, `green`, `yellow`, `pink`, `purple` <br> If not specified, it will take a random color  |
 | _state  | `on` or `playing`    | :material-close: | Define `input_select` state or give manual state for pill to be full |
 | _nav_path |     | :material-close:  | Navigate to another view <br> *Overrides other types of actions*
-| _service_data |     | :material-close:  | Data to be passed through to data_service. Userful for running scripts with custom fields/parameters
+| _service_data |     | :material-close:  | Data to be passed through to data_service. Useful for running scripts with custom fields/parameters
 
 ## Requirement Collapse Function
 

--- a/docs/usage/cards/card_welcome_scenes.md
+++ b/docs/usage/cards/card_welcome_scenes.md
@@ -36,6 +36,7 @@ This is a card which shows the basic needs for your dashboard. This card can gen
 | _color  |  Random    | :material-close: | Color of the icon <br> Can choose between: `blue`, `red`, `green`, `yellow`, `pink`, `purple` <br> If not specified, it will take a random color  |
 | _state  | `on` or `playing`    | :material-close: | Define `input_select` state or give manual state for pill to be full |
 | _nav_path |     | :material-close:  | Navigate to another view <br> *Overrides other types of actions*
+| _service_data |     | :material-close:  | Data to be passed through to data_service. Userful for running scripts with custom fields/parameters
 
 ## Requirement Collapse Function
 


### PR DESCRIPTION
Release v1.3.4<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

This PR allows the ability to have the scenes pill call a script service with custom fields/service_data.

Example:
```
      - type: custom:button-card
        template: card_scenes_welcome
        variables:
          entity_1:
            entity_id: scene.bright_bedroom
            color: yellow
          entity_2:
            entity_id: script.goodnight
            color: blue
            service_data:
              entity_id: script.goodnight
              guests: >-
                [[[ return states['sensor.guest_mode'].state; ]]]
              transition: 5
```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [contribution guidelines](https://github.com/UI-Lovelace-Minimalist/UI/blob/main/.github/CONTRIBUTING.md)
    - [ ] This PR is for a custom-card or documentation change and therefore directed to the `main` branch.
    - [x] This PR is for a official card or any other directly to the integration related change and therefore directed to the `release` branch.
