### PR TITLE
Minor fixes to "custom_card_camera"

### DIFF
--- a/custom_cards/custom_card_camera/README.md
+++ b/custom_cards/custom_card_camera/README.md
@@ -20,6 +20,10 @@ Version: 1.0.0
 ## Changelog
 
 <details>
+<summary>1.0.1</summary>
+Added variable to passthough aspect ratio to the picture entity card. Fix minor issues with title.
+</details>
+<details>
 <summary>1.0.0</summary>
 Initial release.
 </details>
@@ -35,6 +39,7 @@ Initial release.
     ulm_custom_card_camera_title: true
     ulm_custom_card_camera_name: "name"
     ulm_custom_card_camera_label: "label"
+    ulm_custom_card_camera_aspect_ratio: '16:9'
 ```
 
 ## Variables
@@ -67,6 +72,13 @@ Initial release.
 <td>no</td>
 <td></td>
 <td>Label of your choice</td>
+</tr>
+<tr>
+<td>ulm_custom_card_camera_aspect_ratio</td>
+<td>'16:9'</td>
+<td>no</td>
+<td></td>
+<td>Aspect ratio of camera entity</td>
 </tr>
 </table>
 

--- a/custom_cards/custom_card_camera/custom_card_camera.yaml
+++ b/custom_cards/custom_card_camera/custom_card_camera.yaml
@@ -44,6 +44,7 @@ custom_card_camera:
           card:
             - box-shadow: "none"
             - padding: "0"
+            - --mdc-ripple-press-opacity: 0
           name:
             - align-self: "end"
             - justify-self: "start"
@@ -70,5 +71,6 @@ custom_card_camera:
         entity: "[[[ return entity.entity_id ]]]"
         show_name: false
         show_state: false
+        aspect_ratio: "[[[ return variables.ulm_custom_card_camera_aspect_ratio; ]]]"
   tap_action:
     action: "more-info"

--- a/custom_cards/custom_card_camera/custom_card_camera.yaml
+++ b/custom_cards/custom_card_camera/custom_card_camera.yaml
@@ -40,6 +40,9 @@ custom_card_camera:
         show_icon: "[[[ return variables.ulm_custom_card_camera_title; ]]]"
         name: "[[[ return variables.ulm_custom_card_camera_name; ]]]"
         label: "[[[ return variables.ulm_custom_card_camera_label; ]]]"
+        tap_action:
+           action: "more-info"
+           entity: "[[[ return entity.entity_id ]]]"
         styles:
           card:
             - box-shadow: "none"

--- a/custom_cards/custom_card_camera/custom_card_camera.yaml
+++ b/custom_cards/custom_card_camera/custom_card_camera.yaml
@@ -41,8 +41,8 @@ custom_card_camera:
         name: "[[[ return variables.ulm_custom_card_camera_name; ]]]"
         label: "[[[ return variables.ulm_custom_card_camera_label; ]]]"
         tap_action:
-           action: "more-info"
-           entity: "[[[ return entity.entity_id ]]]"
+          action: "more-info"
+          entity: "[[[ return entity.entity_id ]]]"
         styles:
           card:
             - box-shadow: "none"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Additional information
When clicking the title, there is a ripple effect only on the title, which looks odd. This fix removes that ripple effect and also allows the title to open the more-info dialog. It also adds a variable to allow the aspect ratio of the picture-entity card to be customized.

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [contribution guidelines](https://github.com/UI-Lovelace-Minimalist/UI/blob/main/.github/CONTRIBUTING.md)
    - [x] This PR is for a custom-card or documentation change and therefore directed to the `main` branch.
    - [ ] This PR is for a official card or any other directly to the integration related change and therefore directed to the `release` branch.
