### PR TITLE
Add shadow to chips in dark mode

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_welcome_scenes.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_welcome_scenes.yaml
@@ -444,15 +444,6 @@ card_topbar_welcome:
         styles:
           grid:
             - grid-template-areas: "'i'"
-          card:
-            - box-shadow: >
-                [[[
-                  if (hass.themes.darkMode){
-                    return "0px 2px 4px 0px rgba(0,0,0,0.80)";
-                  } else {
-                    return "var(--box-shadow)";
-                  }
-                ]]]
         state:
           - value: "on"
             icon: "mdi:chevron-down"
@@ -475,14 +466,6 @@ card_topbar_welcome:
         styles:
           card:
             - width: "100px"
-            - box-shadow: >
-                [[[
-                  if (hass.themes.darkMode){
-                    return "0px 2px 4px 0px rgba(0,0,0,0.80)";
-                  } else {
-                    return "var(--box-shadow)";
-                  }
-                ]]]
     item3:
       card:
         type: "custom:button-card"
@@ -495,14 +478,6 @@ card_topbar_welcome:
         styles:
           card:
             - align-self: "end"
-            - box-shadow: >
-                [[[
-                  if (hass.themes.darkMode){
-                    return "0px 2px 4px 0px rgba(0,0,0,0.80)";
-                  } else {
-                    return "var(--box-shadow)";
-                  }
-                ]]]
 # auto-entities
 card_scenes_welcome_auto:
   show_icon: false

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/internal_templates/chips.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/internal_templates/chips.yaml
@@ -19,7 +19,14 @@ chips:
       - grid-template-areas: "'l'"
     card:
       - border-radius: "18px"
-      - box-shadow: "var(--box-shadow)"
+      - box-shadow: >
+          [[[
+            if (hass.themes.darkMode){
+              return "0px 2px 4px 0px rgba(0,0,0,0.80)";
+            } else {
+              return "var(--box-shadow)";
+            }
+          ]]]
       - height: "36px"
       - width: "auto"
       - padding-left: "6px"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

Currently chips do not have a visible shadow during dark mode.
Make the shadow of the chips dependent on the theme and darken the shadow when dark mode is enabled.

This approach is already used by the Welcome Scenes Card, which applies it specifically for the chips they used.
This is no longer necessary when we apply this modification to all chips.


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #1343
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [contribution guidelines](https://github.com/UI-Lovelace-Minimalist/UI/blob/main/.github/CONTRIBUTING.md)
    - [ ] This PR is for a custom-card or documentation change and therefore directed to the `main` branch.
    - [x] This PR is for a official card or any other directly to the integration related change and therefore directed to the `release` branch.
