### PR TITLE
Fix z-index of notification icon on custom_card_paddy_waste_collection

### DIFF
--- a/custom_cards/custom_card_paddy_waste_collection/custom_card_paddy_waste_collection.yaml
+++ b/custom_cards/custom_card_paddy_waste_collection/custom_card_paddy_waste_collection.yaml
@@ -20,6 +20,7 @@ custom_card_paddy_waste_collection:
             - border: "2px solid var(--card-background-color)"
             - font-size: "12px"
             - line-height: "14px"
+            - z-index: "1"
             - background-color: >
                 [[[
                   return "rgba(var(--color-red),1)";
@@ -38,6 +39,7 @@ custom_card_paddy_waste_collection:
             - border: "2px solid var(--card-background-color)"
             - font-size: "12px"
             - line-height: "14px"
+            - z-index: "1"
             - background-color: >
                 [[[
                   return "rgba(var(--color-red),1)";
@@ -55,6 +57,7 @@ custom_card_paddy_waste_collection:
             - border: "2px solid var(--card-background-color)"
             - font-size: "12px"
             - line-height: "14px"
+            - z-index: "1"
             - background-color: >
                 [[[
                   return "rgba(var(--color-red),1)";


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #897 
- This PR is related to issue:
- Link to documentation pull request:

Added z-index to notification icon so that it appears on top of the waste icon.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [contribution guidelines](https://github.com/UI-Lovelace-Minimalist/UI/blob/main/.github/CONTRIBUTING.md)
    - [x] This PR is for a custom-card or documentation change and therefore directed to the `main` branch.
    - [ ] This PR is for a official card or any other directly to the integration related change and therefore directed to the `release` branch.
