### PR TITLE
Fix Typo in troubleshooting.md

### DIFF
--- a/docs/troubleshooting/troubleshooting.md
+++ b/docs/troubleshooting/troubleshooting.md
@@ -73,7 +73,7 @@ This is done by:
 
     2. First make sure your configuration file has the setting:
     ```yaml
-    lovalace:
+    lovelace:
       mode: storage
     ```
     3. In case it still shows that error. go to `https://homeassistant.local/config/system_health` and search for what is under: Dashboard -> Mode. if that is on `auto-gen`.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

While I was troubleshooting an issue I found [troubleshooting.md](https://ui-lovelace-minimalist.github.io/UI/troubleshooting/troubleshooting/#most-common-errors) to have a typo in the `HACS Frontend resources are not showing up in https://homeassistant.local/config/lovelace/resources` drop down. This PR fixes the typo `lovalace` -> `lovelace`.

- This PR fixes or closes issue: fixes # `None`
- This PR is related to issue: `None`
- Link to documentation pull request: `None`

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [contribution guidelines](https://github.com/UI-Lovelace-Minimalist/UI/blob/main/.github/CONTRIBUTING.md)
    - [x] This PR is for a custom-card or documentation change and therefore directed to the `main` branch.
    - [ ] This PR is for a official card or any other directly to the integration related change and therefore directed to the `release` branch.
