### PR TITLE
fix tap_action in speedtest custom card

### DIFF
--- a/custom_cards/custom_card_irmajavi_speedtest/custom_card_irmajavi_speedtest.yaml
+++ b/custom_cards/custom_card_irmajavi_speedtest/custom_card_irmajavi_speedtest.yaml
@@ -30,11 +30,9 @@ custom_card_irmajavi_speedtest:
         show_name: true
         show_icon: true
         label: >-
-          [[[ return variables.ulm_custom_card_irmajavi_speedtest_router_model
-          ]]]
+          [[[ return variables.ulm_custom_card_irmajavi_speedtest_router_model ]]]
         name: >-
-          [[[ return variables.ulm_custom_card_irmajavi_speedtest_router_name
-          ]]]
+          [[[ return variables.ulm_custom_card_irmajavi_speedtest_router_name ]]]
         icon: "mdi:wifi"
         styles:
           icon:
@@ -146,15 +144,13 @@ custom_card_irmajavi_speedtest:
           item1:
             card:
               type: "custom:button-card"
-              tap_action:
-                action: "more-info"
               color: "var(--google-blue)"
               show_label: true
               show_icon: false
               name: "[[[ return variables.ulm_custom_card_irmajavi_speedtest_download ]]]"
               entity: >-
                 [[[ return
-                    variables.ulm_custom_card_irmajavi_speedtest_download_speed_entity;
+                variables.ulm_custom_card_irmajavi_speedtest_download_speed_entity;
                 ]]]
               label: |
                 [[[
@@ -209,10 +205,10 @@ custom_card_irmajavi_speedtest:
                 [[[
                     var state1 = "";
                     if (states[variables.ulm_custom_card_irmajavi_speedtest_upload_speed_entity].state){
-                        var state1 = states[variables.ulm_custom_card_irmajavi_speedtest_upload_speed_entity].state;
-                        if (states[variables.ulm_custom_card_irmajavi_speedtest_upload_speed_entity].attributes.unit_of_measurement){
-                          state1 += states[variables.ulm_custom_card_irmajavi_speedtest_upload_speed_entity].attributes.unit_of_measurement;
-                        }
+                      var state1 = states[variables.ulm_custom_card_irmajavi_speedtest_upload_speed_entity].state;
+                      if (states[variables.ulm_custom_card_irmajavi_speedtest_upload_speed_entity].attributes.unit_of_measurement){
+                        state1 += states[variables.ulm_custom_card_irmajavi_speedtest_upload_speed_entity].attributes.unit_of_measurement;
+                      }
                     }
                     return state1;
                 ]]]


### PR DESCRIPTION
remove custom tap_action so more info works naturally. small formatting was applied for consistency in the 2 sensors

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # - small bug that i noticed
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [contribution guidelines](https://github.com/UI-Lovelace-Minimalist/UI/blob/main/.github/CONTRIBUTING.md)
    - [x] This PR is for a custom-card or documentation change and therefore directed to the `main` branch.
    - [ ] This PR is for a official card or any other directly to the integration related change and therefore directed to the `release` branch.
