### PR TITLE
Fix: Update card_mod declarations and correct indentation

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/2-line_cards/card_graph.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/2-line_cards/card_graph.yaml
@@ -83,8 +83,9 @@ card_graph:
         points_per_hour: "[[[ return variables.ulm_card_graph_points; ]]]"
         group_by: "[[[ return variables.ulm_card_graph_group_by; ]]]"
         line_width: "[[[ return variables.ulm_card_graph_line_width; ]]]"
-        style: |
-          ha-card {
-            box-shadow: none;
-            border-radius: var(--border-radius);
-          }
+        card_mod:
+          style: |
+            ha-card {
+              box-shadow: none;
+              border-radius: var(--border-radius);
+            }

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_cover.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_cover.yaml
@@ -622,11 +622,11 @@ card_cover:
         thumbVerticalPadding: "0px"
         thumbWidth: "0px"
         card_mod:
-        style: |
-          ha-card {
-            border-radius: 14px;
-            box-shadow: none;
-          }
+          style: |
+            ha-card {
+              border-radius: 14px;
+              box-shadow: none;
+            }
     item4:
       card:
         type: "custom:button-card"

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_fan.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_fan.yaml
@@ -250,11 +250,11 @@ card_fan:
               thumbVerticalPadding: "0px"
               thumbWidth: "0px"
               card_mod:
-              style: |
-                ha-card {
-                  border-radius: 14px;
-                  box-shadow: none;
-                }
+                style: |
+                  ha-card {
+                    border-radius: 14px;
+                    box-shadow: none;
+                  }
           button:
             card:
               type: "custom:button-card"

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_light.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_light.yaml
@@ -272,11 +272,11 @@ card_light:
         thumbVerticalPadding: "0px"
         thumbWidth: "12px"
         card_mod:
-        style: |
-          ha-card {
-            border-radius: 14px;
-            box-shadow: none;
-          }
+          style: |
+            ha-card {
+              border-radius: 14px;
+              box-shadow: none;
+            }
     item3:
       card:
         type: "custom:button-card"

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_weather.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_weather.yaml
@@ -32,17 +32,18 @@ card_weather:
         secondary_info: "[[[ return variables.ulm_card_weather_secondary_info ]]]"
         backdrop: "[[[ return variables.ulm_card_weather_backdrop ]]]"
         custom: "[[[ return variables?.ulm_card_weather_custom ]]]"
-        style: |
-          ha-card {
-            border-radius: 14px;
-            box-shadow: none;
-          }
-          ha-card.type-custom-simple-weather-card {
-            padding: 24px;
-          }
-          ha-card[bg].type-custom-simple-weather-card{
-            color: white;
-          }
-          ha-card.type-custom-simple-weather-card .weather__info {
-            text-align: left
-          }
+        card_mod:
+          style: |
+            ha-card {
+              border-radius: 14px;
+              box-shadow: none;
+            }
+            ha-card.type-custom-simple-weather-card {
+              padding: 24px;
+            }
+            ha-card[bg].type-custom-simple-weather-card{
+              color: white;
+            }
+            ha-card.type-custom-simple-weather-card .weather__info {
+              text-align: left
+            }

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/internal_templates/extended_card.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/internal_templates/extended_card.yaml
@@ -80,8 +80,9 @@ extended_card:
     item2:
       card:
         type: "custom:button-card"
-        style: |
-          ha-card {
-            box-shadow: none;
-            border-radius: var(--border-radius);
-          }
+        card_mod:
+          style: |
+            ha-card {
+              box-shadow: none;
+              border-radius: var(--border-radius);
+            }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

Card mod styles were not properly applied to certain elements, causing them to display incorrectly. For example, both the graph and slider should not have a box shadow.

![Screenshot 2024-09-09 at 17-09-18 Minimalist – Home Assistant](https://github.com/user-attachments/assets/328e50b2-9003-4a08-9c94-effd7299b1a5)


![Screenshot 2024-09-09 164732](https://github.com/user-attachments/assets/f5c812e1-79a9-4585-9a24-1be34dbbd4e2)

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [contribution guidelines](https://github.com/UI-Lovelace-Minimalist/UI/blob/main/.github/CONTRIBUTING.md)
    - [ ] This PR is for a custom-card or documentation change and therefore directed to the `main` branch.
    - [x] This PR is for a official card or any other directly to the integration related change and therefore directed to the `release` branch.
