### PR TITLE
Remove aiofiles pin

### DIFF
--- a/custom_components/ui_lovelace_minimalist/manifest.json
+++ b/custom_components/ui_lovelace_minimalist/manifest.json
@@ -14,7 +14,6 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/UI-Lovelace-Minimalist/UI/issues",
   "requirements": [
-    "aiofiles==0.8.0",
     "aiogithubapi>=22.2.4"
   ],
   "version": "0.0.1"


### PR DESCRIPTION
This custom integration pins aiofiles to 0.8.0 which has no support for Python 3.12.
Since this version gets installed when users install this custom integration, it can cause some official integrations to break.
I've removed the requirement since your codebase does not longer have references to that dependency.

(Now months later, it also breaks 2024.12+ since Home Assistant runs on Python 3.13 by default) 

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [contribution guidelines](https://github.com/UI-Lovelace-Minimalist/UI/blob/main/.github/CONTRIBUTING.md)
    - [ ] This PR is for a custom-card or documentation change and therefore directed to the `main` branch.
    - [ ] This PR is for a official card or any other directly to the integration related change and therefore directed to the `release` branch.
