### PR TITLE
fix(card_scenes): prevent crash when entity_id is null

### DIFF
--- a/custom_cards/custom_card_scenes/card_scenes.yaml
+++ b/custom_cards/custom_card_scenes/card_scenes.yaml
@@ -59,13 +59,14 @@ card_scenes:
         tap_action:
           action: "perform-action"
           perform_action: |
-            [[[
-              let domain = variables.entity_1.entity_id.substr(0, variables.entity_1.entity_id.indexOf("."));
-              if (domain == "automation") {
-                return "automation.trigger"
-              } else {
-                return "homeassistant.turn_on"
-              }
+            [[[ 
+              const eid = variables.entity_1?.entity_id;
+              if (!eid) return null;
+
+              const domain = eid.split('.')[0];
+              return domain === 'automation'
+                ? 'automation.trigger'
+                : 'homeassistant.turn_on';
             ]]]
           target:
             entity_id: "[[[ return variables.entity_1.entity_id ]]]"
@@ -82,13 +83,14 @@ card_scenes:
         tap_action:
           action: "perform-action"
           perform_action: |
-            [[[
-              let domain = variables.entity_2.entity_id.substr(0, variables.entity_2.entity_id.indexOf("."));
-              if (domain == "automation") {
-                return "automation.trigger"
-              } else {
-                return "homeassistant.turn_on"
-              }
+            [[[ 
+              const eid = variables.entity_2?.entity_id;
+              if (!eid) return null;
+
+              const domain = eid.split('.')[0];
+              return domain === 'automation'
+                ? 'automation.trigger'
+                : 'homeassistant.turn_on';
             ]]]
           target:
             entity_id: "[[[ return variables.entity_2.entity_id ]]]"
@@ -105,13 +107,14 @@ card_scenes:
         tap_action:
           action: "perform-action"
           perform_action: |
-            [[[
-              let domain = variables.entity_3.entity_id.substr(0, variables.entity_3.entity_id.indexOf("."));
-              if (domain == "automation") {
-                return "automation.trigger"
-              } else {
-                return "homeassistant.turn_on"
-              }
+            [[[ 
+              const eid = variables.entity_3?.entity_id;
+              if (!eid) return null;
+
+              const domain = eid.split('.')[0];
+              return domain === 'automation'
+                ? 'automation.trigger'
+                : 'homeassistant.turn_on';
             ]]]
           target:
             entity_id: "[[[ return variables.entity_3.entity_id ]]]"
@@ -128,13 +131,14 @@ card_scenes:
         tap_action:
           action: "perform-action"
           perform_action: |
-            [[[
-              let domain = variables.entity_4.entity_id.substr(0, variables.entity_4.entity_id.indexOf("."));
-              if (domain == "automation") {
-                return "automation.trigger"
-              } else {
-                return "homeassistant.turn_on"
-              }
+            [[[ 
+              const eid = variables.entity_4?.entity_id;
+              if (!eid) return null;
+
+              const domain = eid.split('.')[0];
+              return domain === 'automation'
+                ? 'automation.trigger'
+                : 'homeassistant.turn_on';
             ]]]
           target:
             entity_id: "[[[ return variables.entity_4.entity_id ]]]"
@@ -151,13 +155,14 @@ card_scenes:
         tap_action:
           action: "perform-action"
           perform_action: |
-            [[[
-              let domain = variables.entity_5.entity_id.substr(0, variables.entity_5.entity_id.indexOf("."));
-              if (domain == "automation") {
-                return "automation.trigger"
-              } else {
-                return "homeassistant.turn_on"
-              }
+            [[[ 
+              const eid = variables.entity_5?.entity_id;
+              if (!eid) return null;
+
+              const domain = eid.split('.')[0];
+              return domain === 'automation'
+                ? 'automation.trigger'
+                : 'homeassistant.turn_on';
             ]]]
           target:
             entity_id: "[[[ return variables.entity_5.entity_id ]]]"


### PR DESCRIPTION
card_scenes could crash with the following error:

ButtonCardJSTemplateError: Cannot read properties of null (reading 'substr')

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

**Root cause**  
`card_scenes` assumed `entity_id` was always defined and used `.substr()` on it.
When one or more `entity_id` values were `null` or not provided, button-card threw
a runtime error and stopped rendering the entire card.

**Fix**  
- Added defensive checks to ensure `entity_id` exists before processing it
- Replaced unsafe `.substr()` usage with a guarded `split('.')` approach
- Prevented JavaScript execution for empty scene slots

This makes `card_scenes` safe to use with partial or dynamically defined scene lists
and prevents button-card crashes.

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [contribution guidelines](https://github.com/UI-Lovelace-Minimalist/UI/blob/main/.github/CONTRIBUTING.md)
    - [x] This PR is for a custom-card or documentation change and therefore directed to the `main` branch.
    - [ ] This PR is for a official card or any other directly to the integration related change and therefore directed to the `release` branch.
