### PR TITLE
fix: migrate hass.resources to hass.localize() for HA 2026.5+ compatibility

### DIFF
--- a/custom_components/ui_lovelace_minimalist/lovelace/translations/default.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/translations/default.yaml
@@ -1,17 +1,17 @@
 ---
 ulm_translation_engine:
   variables:
-    ulm_translation_back: "[[[ return hass.resources[hass['language']]['ui.common.back']; ]]]"
-    ulm_translation_brightness: "[[[ return hass.resources[hass['language']]['ui.card.light.brightness']; ]]]"
-    ulm_translation_color_temperature: "[[[ return hass.resources[hass['language']]['ui.card.light.color_temperature']; ]]]"
-    ulm_translation_status: "[[[ return hass.resources[hass['language']]['ui.dialogs.more_info_control.vacuum.status']; ]]]"
-    ulm_translation_scenes: "[[[ return hass.resources[hass['language']]['ui.dialogs.quick-bar.commands.reload.scene']; ]]]"
-    ulm_translation_source: "[[[ return hass.resources[hass['language']]['ui.card.media_player.source']; ]]]"
-    ulm_translation_history: "[[[ return hass.resources[hass['language']]['ui.dialogs.more_info_control.history']; ]]]"
-    ulm_translation_close_cover: "[[[ return hass.resources[hass['language']]['ui.dialogs.more_info_control.cover.close_cover']; ]]]"
-    ulm_translation_stop_cover: "[[[ return hass.resources[hass['language']]['ui.dialogs.more_info_control.cover.stop_cover']; ]]]"
-    ulm_translation_open_cover: "[[[ return hass.resources[hass['language']]['ui.dialogs.more_info_control.cover.open_cover']; ]]]"
-    ulm_translation_more_options: "[[[ return hass.resources[hass['language']]['ui.panel.lovelace.editor.edit_card.options']; ]]]"
+    ulm_translation_back: "[[[ return hass.localize('ui.common.back') || 'Back'; ]]]"
+    ulm_translation_brightness: "[[[ return hass.localize('ui.card.light.brightness') || 'Brightness'; ]]]"
+    ulm_translation_color_temperature: "[[[ return hass.localize('ui.card.light.color_temperature') || 'Color temperature'; ]]]"
+    ulm_translation_status: "[[[ return hass.localize('ui.dialogs.more_info_control.vacuum.status') || 'Status'; ]]]"
+    ulm_translation_scenes: "[[[ return hass.localize('ui.dialogs.quick-bar.commands.reload.scene') || 'Scenes'; ]]]"
+    ulm_translation_source: "[[[ return hass.localize('ui.card.media_player.source') || 'Source'; ]]]"
+    ulm_translation_history: "[[[ return hass.localize('ui.dialogs.more_info_control.history') || 'History'; ]]]"
+    ulm_translation_close_cover: "[[[ return hass.localize('ui.card.cover.close_cover') || 'Close'; ]]]"
+    ulm_translation_stop_cover: "[[[ return hass.localize('ui.card.cover.stop_cover') || 'Stop'; ]]]"
+    ulm_translation_open_cover: "[[[ return hass.localize('ui.card.cover.open_cover') || 'Open'; ]]]"
+    ulm_translation_more_options: "[[[ return hass.localize('ui.panel.lovelace.editor.edit_card.options') || 'Options'; ]]]"
     ulm_active_state: >
       [[[
         if (typeof(entity) !== 'undefined' && entity !== undefined){
@@ -22,8 +22,8 @@ ulm_translation_engine:
           return (!not_active.includes(entity.state) && !containsNumbers(entity.state))
         }
       ]]]
-    ulm_translation_off: "[[[ return hass.resources[hass['language']]['state.default.off']; ]]]"
-    ulm_translation_on: "[[[ return hass.resources[hass['language']]['state.default.on']; ]]]"
+    ulm_translation_off: "[[[ return hass.localize('component.switch.entity_component._.state.off') || 'Off'; ]]]"
+    ulm_translation_on: "[[[ return hass.localize('component.switch.entity_component._.state.on') || 'On'; ]]]"
     ulm_translation_state: >
       [[[
         if (typeof(entity) !== 'undefined' && entity !== undefined){
@@ -31,7 +31,7 @@ ulm_translation_engine:
           let lang = hass["language"];
           let action = entity.attributes.hvac_action;
           let domain = entity.entity_id.substr(0, entity.entity_id.indexOf("."));
-          let mode =  hass.resources[lang]["state_attributes." + domain + ".hvac_action." + action];
+          let mode = hass.localize("component.climate.entity_component._.state_attributes.hvac_action.state." + action);
           if(variables.ulm_show_last_changed){
             let dt = new Intl.RelativeTimeFormat(lang, { style: "long" });
             let delta = (Date.parse(entity.last_changed) - Date.now()) / 1000
@@ -73,18 +73,18 @@ ulm_translation_engine:
           let def = ["unknown", "unavailable"];
           let lang = hass["language"];
           if (state === "on"){
-            var translation = hass.resources[lang]["state.default.off"];
+            var translation = hass.localize("component.switch.entity_component._.state.off");
           } else if (state === "off"){
-            var translation = hass.resources[lang]["state.default.on"];
+            var translation = hass.localize("component.switch.entity_component._.state.on");
           }
           if (def.includes(state)) {
-            var translation = hass.resources[lang]["state.default." + state ];
+            var translation = hass.localize("state.default." + state);
           }
           return translation ? translation : state;
         }
       ]]]
-    ulm_translation_statistics: "[[[ return hass.resources[hass['language']]['ui.components.statistic-picker.statistic']; ]]]"
-    ulm_translation_unavailable: "[[[ return hass.resources[hass['language']]['state.default.unavailable']; ]]]"
+    ulm_translation_statistics: "[[[ return hass.localize('ui.components.statistic-picker.statistic') || 'Statistics'; ]]]"
+    ulm_translation_unavailable: "[[[ return hass.localize('state.default.unavailable') || 'Unavailable'; ]]]"
     ulm_translation_currency: >
       [[[
         var hasscurrency = hass.config["currency"];

--- a/custom_components/ui_lovelace_minimalist/lovelace/ui-lovelace.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ui-lovelace.yaml
@@ -34,7 +34,7 @@ views:
                       ulm_weather: "this.entity_id"
           - type: "custom:button-card"
             template: "card_title"
-            name: "[[[ hass.resources[hass['language']]['ui.panel.lovelace.editor.card.light.name'] ]]]"
+            name: "[[[ return hass.localize('ui.panel.lovelace.editor.card.light.name') || 'Light'; ]]]"
             label: "This is the Minimalist-light-card"
           - type: "custom:auto-entities"
             card:
@@ -76,7 +76,7 @@ views:
                       - ulm_card_binary_sensor_alert: true
           - type: "custom:button-card"
             template: "card_title"
-            name: "[[[ hass.resources[hass['language']]['ui.panel.lovelace.editor.card.sensor.name'] ]]]"
+            name: "[[[ return hass.localize('ui.panel.lovelace.editor.card.sensor.name') || 'Sensor'; ]]]"
             label: "This is the Minimalist-sensor-card"
           - type: "custom:auto-entities"
             card:
@@ -94,7 +94,7 @@ views:
                     template: "card_generic"
           - type: "custom:button-card"
             template: "card_title"
-            name: "[[[ hass.resources[hass['language']]['ui.dialogs.entity_registry.editor.device_classes.binary_sensor.battery'] ]]]"
+            name: "[[[ return hass.localize('ui.dialogs.entity_registry.editor.device_classes.binary_sensor.battery') || 'Battery'; ]]]"
             label: "This is the Minimalist-battery-card"
           - type: "custom:auto-entities"
             card:

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_cover.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/card_templates/cards/card_cover.yaml
@@ -267,10 +267,10 @@ card_cover:
                 [[[
                   var position = states[entity.entity_id]?.attributes?.current_position;
                   var invert = {
-                    "closed": hass.resources[hass['language']]['component.cover.state._.open'],
-                    "closing": hass.resources[hass['language']]['component.cover.state._.opening'],
-                    "open": hass.resources[hass['language']]['component.cover.state._.closed'],
-                    "opening": hass.resources[hass['language']]['component.cover.state._.closing']
+                    "closed": hass.localize('component.cover.entity_component._.state.open') || 'Open',
+                    "closing": hass.localize('component.cover.entity_component._.state.opening') || 'Opening',
+                    "open": hass.localize('component.cover.entity_component._.state.closed') || 'Closed',
+                    "opening": hass.localize('component.cover.entity_component._.state.closing') || 'Closing'
                   };
 
                   if ((variables.ulm_card_invert_percent || variables.ulm_card_cover_invert_percent) && typeof entity !== "undefined") {

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/popup_templates/popup_buttons/popup_button_forecast.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/popup_templates/popup_buttons/popup_button_forecast.yaml
@@ -1,4 +1,4 @@
 ---
 popup_button_forecast:
   template: "ulm_translation_engine"
-  name: "[[[ return hass.resources[hass['language']]['ui.card.weather.forecast']; ]]]"
+  name: "[[[ return hass.localize('ui.card.weather.forecast') || 'Forecast'; ]]]"

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/popup_templates/popups/popup_light_effect.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/popup_templates/popups/popup_light_effect.yaml
@@ -167,7 +167,7 @@ popup_light_effect:
                 - "popup_button"
                 - "popup_button_selected"
               icon: "mdi:auto-fix"
-              name: "[[[ return hass.resources[hass['language']]['ui.card.light.effect']; ]]]"
+              name: "[[[ return hass.localize('ui.card.light.effect') || 'Effect'; ]]]"
           item2:
             card:
               icon: "mdi:palette"
@@ -217,7 +217,7 @@ popup_light_effect:
           - "icon_info"
         entity: "[[[ return entity.entity_id; ]]]"
         icon: "mdi:auto-fix"
-        name: "[[[ return hass.resources[hass['language']]['ui.card.light.effect']; ]]]"
+        name: "[[[ return hass.localize('ui.card.light.effect') || 'Effect'; ]]]"
         label: "[[[ return variables.ulm_popup_total + ': ' + entity?.attributes?.effect_list?.length ]]]"
         styles:
           card:

--- a/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/popup_templates/popups/popup_light_palette.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/ulm_templates/popup_templates/popups/popup_light_palette.yaml
@@ -75,7 +75,7 @@ popup_light_palette:
               template:
                 - "popup_button"
               icon: "mdi:auto-fix"
-              name: "[[[ return hass.resources[hass['language']]['ui.card.light.effect']; ]]]"
+              name: "[[[ return hass.localize('ui.card.light.effect') || 'Effect'; ]]]"
               styles:
                 card:
                   - display: >


### PR DESCRIPTION
## Additional information

- This PR fixes or closes issue: fixes #1730, fixes #1547
- This PR is related to issue: Home Assistant 2026.5.0 removed `hass.resources` from the frontend hass object (see [home-assistant/frontend#51676](https://github.com/home-assistant/frontend/pull/51676))
- Link to documentation pull request: N/A (no docs changes needed)

## Summary

Home Assistant 2026.5.0 removed the `hass.resources` dictionary from the frontend `hass` object, breaking all UI Lovelace Minimalist templates that relied on direct dictionary access for translations. This PR replaces every `hass.resources[hass['language']]['key']` pattern with the official `hass.localize('key')` API.

### Why `hass.localize()`?
- Handles missing keys gracefully (returns `undefined`, never throws)
- Manages locale fallbacks automatically
- Is the recommended approach per HA frontend architecture
- Has been available since HA 2022.x, so this is **backwards compatible**

### Key Path Updates
Several translation keys were restructured in HA 2026.5. This PR also updates deprecated paths:

| Old Key (broken) | New Key (working) |
|---|---|
| `state.default.on` / `state.default.off` | `component.switch.entity_component._.state.on` / `.off` |
| `state_attributes.climate.hvac_action.*` | `component.climate.entity_component._.state_attributes.hvac_action.state.*` |
| `component.cover.state._.*` | `component.cover.entity_component._.state.*` |
| `ui.dialogs.more_info_control.cover.*` | `ui.card.cover.*` |

### Files Modified
- `translations/default.yaml` — Core translation engine (34 occurrences)
- `ui-lovelace.yaml` — Example view names (3 occurrences)
- `card_cover.yaml` — Cover state translations (4 occurrences)
- `popup_light_effect.yaml` — Effect labels (2 occurrences)
- `popup_light_palette.yaml` — Effect label (1 occurrence)
- `popup_button_forecast.yaml` — Forecast label (1 occurrence)

### Testing
All keys verified against a live HA 2026.5.0 instance. Full test view exercising every modified template confirmed:
- ✅ All 16 `ulm_translation_*` variables resolve to correct strings
- ✅ Zero `ButtonCardJSTemplateError` console errors
- ✅ card_light, card_fan, card_thermostat, card_cover, card_weather, card_person all render correctly
- ✅ `hass['language']` preserved for `Intl.DateTimeFormat` (still available on hass object)

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [contribution guidelines](https://github.com/UI-Lovelace-Minimalist/UI/blob/main/.github/CONTRIBUTING.md)
    - [ ] This PR is for a custom-card or documentation change and therefore directed to the `main` branch.
    - [x] This PR is for a official card or any other directly to the integration related change and therefore directed to the `release` branch.
