### PR TITLE
fix: migrate custom_card_person_* from hass.resources to hass.localize()

### DIFF
--- a/custom_cards/custom_card_person_chip/custom_card_person_chip.yaml
+++ b/custom_cards/custom_card_person_chip/custom_card_person_chip.yaml
@@ -13,7 +13,7 @@ custom_card_person_chip:
   label: >
     [[[
       let state = states[variables.ulm_custom_card_person_chip_entity].state;
-      return hass.resources[hass["language"]]["component.person.entity_component._.state." + state] || state;
+      return hass.localize("component.person.entity_component._.state." + state) || state;
     ]]]
   show_entity_picture: true
   entity_picture: "[[[ return states[variables.ulm_custom_card_person_chip_entity].attributes.entity_picture ]]]"

--- a/custom_cards/custom_card_person_info/custom_card_person_info.yaml
+++ b/custom_cards/custom_card_person_info/custom_card_person_info.yaml
@@ -33,7 +33,7 @@ card_person_info:
         return `Driving - ${variables.ulm_translation_state}`;
       } else {
         let state = states[variables.ulm_card_person_entity].state;
-        return hass.resources[hass["language"]]["component.person.entity_component._.state." + state] ? hass.resources[hass["language"]]["component.person.entity_component._.state." + state] : state;
+        return hass.localize("component.person.entity_component._.state." + state) || state;
       }
     ]]]
   name: "[[[ return states[variables.ulm_card_person_entity].attributes.friendly_name ]]]"

--- a/custom_cards/custom_card_person_info_small/custom_card_person_info_small.yaml
+++ b/custom_cards/custom_card_person_info_small/custom_card_person_info_small.yaml
@@ -39,7 +39,7 @@ card_person_info_small:
         return `Driving - ${variables.ulm_translation_state}`;
       } else {
         let state = states[variables.ulm_card_person_entity].state;
-        return hass.resources[hass["language"]]["component.person.entity_component._.state." + state] ? hass.resources[hass["language"]]["component.person.entity_component._.state." + state] : state;
+        return hass.localize("component.person.entity_component._.state." + state) || state;
       }
     ]]]
   name: "[[[ return states[variables.ulm_card_person_entity].attributes.friendly_name ]]]"


### PR DESCRIPTION
## Additional information

- This PR fixes or closes issue: related to #1730, #1547
- This PR is related to issue: Companion to #1732 (core templates, targeting `release`)
- Link to documentation pull request: N/A

## Summary

Home Assistant 2026.5.0 removed the `hass.resources` dictionary from the frontend `hass` object. This PR updates the three person custom cards that relied on direct dictionary access for state translations to use the official `hass.localize()` API instead.

### Files Modified
- `custom_cards/custom_card_person_info/custom_card_person_info.yaml` — Person info card label
- `custom_cards/custom_card_person_chip/custom_card_person_chip.yaml` — Person chip label
- `custom_cards/custom_card_person_info_small/custom_card_person_info_small.yaml` — Small person info card label

### Changes

All three files used the same pattern for translating person states:

```diff
-return hass.resources[hass["language"]]["component.person.entity_component._.state." + state] ? hass.resources[...] : state;
+return hass.localize("component.person.entity_component._.state." + state) || state;
```

The translation key path (`component.person.entity_component._.state.*`) is unchanged — only the access method is updated.

### Testing
All three cards verified on a live HA 2026.5.0 instance:
- ✅ `custom_card_person_info` renders correctly with translated state labels
- ✅ `custom_card_person_chip` renders correctly with translated state labels
- ✅ `custom_card_person_info_small` renders correctly with translated state labels
- ✅ Zero `ButtonCardJSTemplateError` console errors

### Note on remaining `hass.resources` usage
The bundled JS cards (`light-entity-card.js`, `simple-weather-card.js`) also use `hass.resources` but are minified webpack bundles from upstream third-party repos. A tracking issue will be opened separately for those.

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [contribution guidelines](https://github.com/UI-Lovelace-Minimalist/UI/blob/main/.github/CONTRIBUTING.md)
    - [x] This PR is for a custom-card or documentation change and therefore directed to the `main` branch.
    - [ ] This PR is for a official card or any other directly to the integration related change and therefore directed to the `release` branch.