### PR TITLE
Fix mobile/iOS tapbar themes for Home Assistant 2026 frontend

### DIFF
--- a/custom_components/ui_lovelace_minimalist/base.py
+++ b/custom_components/ui_lovelace_minimalist/base.py
@@ -414,6 +414,15 @@ class UlmBase:
                 ]
             )
 
+            # Home Assistant 2026+ renders the Lovelace header/tab bar inside
+            # hui-root shadow DOM and card-mod theme root styles may not be
+            # applied there. Load a tiny compatibility module globally; it
+            # activates only for the minimalist-mobile-tapbar theme.
+            add_extra_js_url(
+                self.hass,
+                "/ui_lovelace_minimalist/cards/hermes-mobile-tapbar-fix/hermes-mobile-tapbar-fix.js",
+            )
+
         except MinimalistException as exception:
             self.log.error(exception)
             self.disable_ulm(UlmDisabledReason.LOAD_ULM)

--- a/custom_components/ui_lovelace_minimalist/cards/hermes-mobile-tapbar-fix/hermes-mobile-tapbar-fix.js
+++ b/custom_components/ui_lovelace_minimalist/cards/hermes-mobile-tapbar-fix/hermes-mobile-tapbar-fix.js
@@ -30,15 +30,35 @@
     }
     ha-tab-group {
       display: flex !important;
-      justify-content: space-evenly !important;
-      width: 97% !important;
+      justify-content: flex-start !important;
+      width: 100% !important;
+      min-width: 0 !important;
+      overflow: hidden !important;
+    }
+    ha-tab-group::part(base),
+    ha-tab-group::part(nav) {
+      width: 100% !important;
+      min-width: 0 !important;
+      overflow-x: auto !important;
+      overflow-y: hidden !important;
+      -webkit-overflow-scrolling: touch;
+      scrollbar-width: none;
+    }
+    ha-tab-group::part(nav)::-webkit-scrollbar {
+      display: none;
+    }
+    ha-tab-group::part(tabs) {
+      width: max-content !important;
+      min-width: max-content !important;
+      display: flex !important;
     }
     ha-tab-group-tab,
     ha-tab,
     paper-tab,
     sl-tab {
-      flex: 1 1 auto !important;
-      min-width: unset !important;
+      flex: 0 0 56px !important;
+      width: 56px !important;
+      min-width: 56px !important;
       justify-content: center !important;
     }
   `;

--- a/custom_components/ui_lovelace_minimalist/cards/hermes-mobile-tapbar-fix/hermes-mobile-tapbar-fix.js
+++ b/custom_components/ui_lovelace_minimalist/cards/hermes-mobile-tapbar-fix/hermes-mobile-tapbar-fix.js
@@ -1,7 +1,12 @@
-// UI Lovelace Minimalist mobile tapbar compatibility patch for Home Assistant 2026+
-// Runs only when the selected/card-mod theme is "minimalist-mobile-tapbar".
+// UI Lovelace Minimalist tapbar compatibility patch for Home Assistant 2026+
+// Runs only when the selected/card-mod theme is a Minimalist tapbar theme.
 (function () {
   const STYLE_ID = "ulm-mobile-tapbar-ha2026-fix";
+  const TAPBAR_THEMES = new Set([
+    "minimalist-mobile-tapbar",
+    "minimalist-ios-tapbar",
+  ]);
+
   const CSS = `
     .header {
       position: fixed !important;
@@ -16,7 +21,7 @@
       box-shadow: var(--footer-shadow, 0px -1px 3px 0px rgba(0,0,0,0.12));
     }
     .toolbar {
-      height: var(--header-base-height, 70px) !important;
+      height: var(--header-height, var(--header-base-height, 70px)) !important;
       padding-bottom: env(safe-area-inset-bottom) !important;
     }
     #view {
@@ -41,13 +46,13 @@
   function selectedThemeMatches() {
     try {
       const raw = localStorage.getItem("selectedTheme");
-      if (raw && JSON.parse(raw).theme === "minimalist-mobile-tapbar") return true;
+      if (raw && TAPBAR_THEMES.has(JSON.parse(raw).theme)) return true;
     } catch (_) {}
 
     const theme = getComputedStyle(document.documentElement)
       .getPropertyValue("--card-mod-theme")
       .trim();
-    return theme === "minimalist-mobile-tapbar";
+    return TAPBAR_THEMES.has(theme);
   }
 
   function findHuiRootShadow() {

--- a/custom_components/ui_lovelace_minimalist/cards/hermes-mobile-tapbar-fix/hermes-mobile-tapbar-fix.js
+++ b/custom_components/ui_lovelace_minimalist/cards/hermes-mobile-tapbar-fix/hermes-mobile-tapbar-fix.js
@@ -58,10 +58,22 @@
     return root?.shadowRoot;
   }
 
+  function isMobileViewport() {
+    // Do not run the bottom tapbar fix on desktop-width layouts. Otherwise the
+    // fixed bottom header can cover HA sidebar items such as the user/profile
+    // icon at the bottom of the sidebar.
+    return window.matchMedia("(max-width: 767px)").matches;
+  }
+
   function apply() {
-    if (!selectedThemeMatches()) return false;
     const root = findHuiRootShadow();
     if (!root) return false;
+
+    if (!selectedThemeMatches() || !isMobileViewport()) {
+      const style = root.getElementById(STYLE_ID);
+      if (style) style.remove();
+      return false;
+    }
 
     let style = root.getElementById(STYLE_ID);
     if (!style) {
@@ -81,6 +93,7 @@
   }
 
   window.addEventListener("location-changed", schedule);
+  window.addEventListener("resize", schedule);
   window.addEventListener("hashchange", schedule);
   window.addEventListener("storage", schedule);
   document.addEventListener("visibilitychange", schedule);

--- a/custom_components/ui_lovelace_minimalist/cards/hermes-mobile-tapbar-fix/hermes-mobile-tapbar-fix.js
+++ b/custom_components/ui_lovelace_minimalist/cards/hermes-mobile-tapbar-fix/hermes-mobile-tapbar-fix.js
@@ -1,0 +1,89 @@
+// UI Lovelace Minimalist mobile tapbar compatibility patch for Home Assistant 2026+
+// Runs only when the selected/card-mod theme is "minimalist-mobile-tapbar".
+(function () {
+  const STYLE_ID = "ulm-mobile-tapbar-ha2026-fix";
+  const CSS = `
+    .header {
+      position: fixed !important;
+      top: auto !important;
+      bottom: 0px !important;
+      left: 0 !important;
+      right: 0 !important;
+      width: 100% !important;
+      z-index: 999 !important;
+      height: var(--header-height, 70px) !important;
+      transform: none !important;
+      box-shadow: var(--footer-shadow, 0px -1px 3px 0px rgba(0,0,0,0.12));
+    }
+    .toolbar {
+      height: var(--header-base-height, 70px) !important;
+      padding-bottom: env(safe-area-inset-bottom) !important;
+    }
+    #view {
+      padding-top: 0 !important;
+      padding-bottom: var(--header-height, 70px) !important;
+    }
+    ha-tab-group {
+      display: flex !important;
+      justify-content: space-evenly !important;
+      width: 97% !important;
+    }
+    ha-tab-group-tab,
+    ha-tab,
+    paper-tab,
+    sl-tab {
+      flex: 1 1 auto !important;
+      min-width: unset !important;
+      justify-content: center !important;
+    }
+  `;
+
+  function selectedThemeMatches() {
+    try {
+      const raw = localStorage.getItem("selectedTheme");
+      if (raw && JSON.parse(raw).theme === "minimalist-mobile-tapbar") return true;
+    } catch (_) {}
+
+    const theme = getComputedStyle(document.documentElement)
+      .getPropertyValue("--card-mod-theme")
+      .trim();
+    return theme === "minimalist-mobile-tapbar";
+  }
+
+  function findHuiRootShadow() {
+    const ha = document.querySelector("home-assistant");
+    const main = ha?.shadowRoot?.querySelector("home-assistant-main");
+    const panel = main?.shadowRoot?.querySelector("ha-panel-lovelace");
+    const root = panel?.shadowRoot?.querySelector("hui-root");
+    return root?.shadowRoot;
+  }
+
+  function apply() {
+    if (!selectedThemeMatches()) return false;
+    const root = findHuiRootShadow();
+    if (!root) return false;
+
+    let style = root.getElementById(STYLE_ID);
+    if (!style) {
+      style = document.createElement("style");
+      style.id = STYLE_ID;
+      root.appendChild(style);
+    }
+    if (style.textContent !== CSS) style.textContent = CSS;
+    return true;
+  }
+
+  function schedule() {
+    apply();
+    setTimeout(apply, 500);
+    setTimeout(apply, 1500);
+    setTimeout(apply, 4000);
+  }
+
+  window.addEventListener("location-changed", schedule);
+  window.addEventListener("hashchange", schedule);
+  window.addEventListener("storage", schedule);
+  document.addEventListener("visibilitychange", schedule);
+  schedule();
+  setInterval(apply, 5000);
+})();

--- a/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-ios-tapbar/minimalist-ios-tapbar.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-ios-tapbar/minimalist-ios-tapbar.yaml
@@ -31,6 +31,13 @@ minimalist-ios-tapbar:
       #tabsContent {
         width: 97%;
       }
+    sl-tab-group$: |
+      #tabsContainer, #tabsContent {
+        width: 97%;
+      }
+      ::part(active-tab-indicator) {
+        display: none !important;
+      }
       paper-icon-button {
         display: none;
       }
@@ -58,24 +65,32 @@ minimalist-ios-tapbar:
         padding-top: calc(-1 * var(--header-height)) !important;
         padding-bottom: var(--header-height) !important;
       }
-      ha-tabs {
+      ha-tabs, sl-tab-group {
         --paper-tabs-selection-bar-color: var(--header-tab-indicator-color) !important;
         --mdc-icon-size: 26px;
         display: flex;
         justify-content: space-between;
         padding: 10px;
-        margin-top:15px;
-        height:var(--header-height) !important;
+        margin-top: 15px;
+        height: var(--header-height) !important;
+        align-self: unset !important;
       }
-      paper-tab[aria-selected=true] {
+      sl-tab-group::part(active-tab-indicator) {
+        display: none !important;
+      }
+      paper-tab[aria-selected=true], sl-tab[aria-selected=true] {
         color: var(--header-active-tab-color);
         background-color: var(--header-active-tab-bg-color);
       }
-      paper-tab {
+      paper-tab, sl-tab {
         color: var(--header-all-tabs-color);
         border-radius: 25px;
-        height:50px;
+        height: 50px !important;
         padding: 0 20px;
+      }
+      sl-tab.icon::part(base) {
+        padding-top: 10px !important;
+        padding-bottom: 0 !important;
       }
   # Color themes
   modes:

--- a/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-mobile-tapbar/minimalist-mobile-tapbar.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-mobile-tapbar/minimalist-mobile-tapbar.yaml
@@ -39,6 +39,65 @@ minimalist-mobile-tapbar:
       ::part(active-tab-indicator) {
         display: none !important;
       }
+
+    # Home Assistant 2026+ nests Lovelace header inside shadow roots. Keep the
+    # classic root-level rules above, and also target the known nested hosts.
+    home-assistant-main$: |
+      app-drawer-layout partial-panel-resolver ha-panel-lovelace hui-root app-header,
+      app-drawer-layout partial-panel-resolver ha-panel-lovelace hui-root .header {
+        position: fixed !important;
+        top: auto !important;
+        bottom: 0px !important;
+        left: 0 !important;
+        right: 0 !important;
+        width: 100% !important;
+        z-index: 10 !important;
+        box-shadow: var(--footer-shadow);
+        height: var(--header-height) !important;
+        transform: none !important;
+      }
+      app-drawer-layout partial-panel-resolver ha-panel-lovelace hui-root #view {
+        padding-bottom: var(--header-height) !important;
+      }
+    ha-panel-lovelace$: |
+      hui-root app-header,
+      hui-root .header {
+        position: fixed !important;
+        top: auto !important;
+        bottom: 0px !important;
+        left: 0 !important;
+        right: 0 !important;
+        width: 100% !important;
+        z-index: 10 !important;
+        box-shadow: var(--footer-shadow);
+        height: var(--header-height) !important;
+        transform: none !important;
+      }
+      hui-root #view {
+        padding-bottom: var(--header-height) !important;
+      }
+    hui-root$: |
+      app-header,
+      .header {
+        position: fixed !important;
+        top: auto !important;
+        bottom: 0px !important;
+        left: 0 !important;
+        right: 0 !important;
+        width: 100% !important;
+        z-index: 10 !important;
+        box-shadow: var(--footer-shadow);
+        height: var(--header-height) !important;
+        transform: none !important;
+      }
+      app-toolbar,
+      .toolbar {
+        height: var(--header-base-height) !important;
+        padding-bottom: env(safe-area-inset-bottom) !important;
+      }
+      #view {
+        padding-bottom: var(--header-height) !important;
+      }
     .: |
       app-header, .header {
         position: fixed !important;

--- a/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-mobile-tapbar/minimalist-mobile-tapbar.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-mobile-tapbar/minimalist-mobile-tapbar.yaml
@@ -27,6 +27,26 @@ minimalist-mobile-tapbar:
       }
 
   # Move navbar
+
+  # HA 2026/card-mod patches the new top app bar as a separate element type.
+  card-mod-top-app-bar-fixed-yaml: |
+    .: |
+      :host, ha-top-app-bar-fixed, app-header, .header {
+        position: fixed !important;
+        top: auto !important;
+        bottom: 0px !important;
+        left: 0 !important;
+        right: 0 !important;
+        width: 100% !important;
+        z-index: 10 !important;
+        box-shadow: var(--footer-shadow);
+        height: var(--header-height) !important;
+        transform: none !important;
+      }
+      app-toolbar, .toolbar {
+        height: var(--header-base-height) !important;
+        padding-bottom: env(safe-area-inset-bottom) !important;
+      }
   card-mod-root-yaml: |
     ha-tabs$: |
       #tabsContent {

--- a/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-mobile-tapbar/minimalist-mobile-tapbar.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-mobile-tapbar/minimalist-mobile-tapbar.yaml
@@ -47,6 +47,43 @@ minimalist-mobile-tapbar:
         height: var(--header-base-height) !important;
         padding-bottom: env(safe-area-inset-bottom) !important;
       }
+
+  # Plain card-mod root is required by newer HA/card-mod combinations. The
+  # legacy card-mod-root-yaml block below is kept for compatibility.
+  card-mod-root: |
+    .header {
+      position: fixed !important;
+      top: auto !important;
+      bottom: 0px !important;
+      left: 0 !important;
+      right: 0 !important;
+      width: 100% !important;
+      z-index: 10 !important;
+      box-shadow: var(--footer-shadow);
+      height: var(--header-height) !important;
+      transform: none !important;
+    }
+    .toolbar {
+      height: var(--header-base-height) !important;
+      padding-bottom: env(safe-area-inset-bottom) !important;
+    }
+    #view {
+      padding-top: 0 !important;
+      padding-bottom: var(--header-height) !important;
+    }
+    ha-tab-group {
+      display: flex !important;
+      justify-content: space-evenly !important;
+      width: 97% !important;
+    }
+    ha-tab-group-tab,
+    ha-tab,
+    paper-tab,
+    sl-tab {
+      flex: 1 1 auto !important;
+      min-width: unset !important;
+      justify-content: center !important;
+    }
   card-mod-root-yaml: |
     ha-tabs$: |
       #tabsContent {

--- a/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-mobile-tapbar/minimalist-mobile-tapbar.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-mobile-tapbar/minimalist-mobile-tapbar.yaml
@@ -32,6 +32,13 @@ minimalist-mobile-tapbar:
       #tabsContent {
         width: 97%;
       }
+    sl-tab-group$: |
+      #tabsContainer, #tabsContent {
+        width: 97%;
+      }
+      ::part(active-tab-indicator) {
+        display: none !important;
+      }
     .: |
       .header {
         top: auto !important;
@@ -51,26 +58,34 @@ minimalist-mobile-tapbar:
         padding-top: calc(-1 * var(--header-height)) !important;
         padding-bottom: var(--header-height) !important;
       }
-      ha-tabs {
+      ha-tabs, sl-tab-group {
         --paper-tabs-selection-bar-color: var(--header-tab-indicator-color);
         --mdc-icon-size: 26px;
         display: flex;
         justify-content: space-between;
         padding: 0 10px;
-        height:50px !important;
+        height: 50px !important;
+        align-self: unset !important;
       }
-      paper-tab[aria-selected=true] {
+      sl-tab-group::part(active-tab-indicator) {
+        display: none !important;
+      }
+      paper-tab[aria-selected=true], sl-tab[aria-selected=true] {
         color: var(--header-active-tab-color);
         background-color: var(--header-active-tab-bg-color);
       }
-      paper-tab {
+      paper-tab, sl-tab {
         color: var(--header-all-tabs-color);
         border-radius: 25px;
-        height:50px;
+        height: 50px !important;
         /*width: calc(100% / 4);
         padding: 0;*/
         padding-left: 20px;
         padding-right: 20px;
+      }
+      sl-tab.icon::part(base) {
+        padding-top: 10px !important;
+        padding-bottom: 0 !important;
       }
 
   # Color themes

--- a/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-mobile-tapbar/minimalist-mobile-tapbar.yaml
+++ b/custom_components/ui_lovelace_minimalist/lovelace/themefiles/minimalist-mobile-tapbar/minimalist-mobile-tapbar.yaml
@@ -40,13 +40,19 @@ minimalist-mobile-tapbar:
         display: none !important;
       }
     .: |
-      .header {
+      app-header, .header {
+        position: fixed !important;
         top: auto !important;
         bottom: 0px !important;
+        left: 0 !important;
+        right: 0 !important;
+        width: 100% !important;
+        z-index: 10 !important;
         box-shadow: var(--footer-shadow);
         height: var(--header-height) !important;
+        transform: none !important;
       }
-      .toolbar {
+      app-toolbar, .toolbar {
         height: var(--header-base-height) !important;
         padding-bottom: env(safe-area-inset-bottom) !important;
       }


### PR DESCRIPTION
## Summary

This PR restores the mobile tapbar behavior for current Home Assistant frontend versions.

It updates the Minimalist tapbar themes to handle the newer Lovelace/header/tab DOM used by Home Assistant 2026+, including `ha-tab-group` / `ha-tab-group-tab` and nested `hui-root` shadow DOM.

## Changes

- Update `minimalist-mobile-tapbar` selectors for newer HA tab/header elements.
- Update `minimalist-ios-tapbar` compatibility for the same HA frontend changes.
- Add a small compatibility JS module that:
  - runs only for `minimalist-mobile-tapbar` and `minimalist-ios-tapbar`
  - only activates on mobile/responsive widths (`max-width: 767px`)
  - moves the Lovelace header/tab navigation to the bottom in HA 2026+ shadow DOM
  - removes itself on desktop-width layouts so the HA sidebar/profile area is not covered
  - keeps the bottom navigation horizontally scrollable when dashboards have more tabs than fit on screen

## Why this is needed

The old tapbar CSS targets older elements such as `ha-tabs` / `paper-tab`. Newer Home Assistant versions render the dashboard tabs/header differently, so the old `card-mod-root` styling may not reach the real `hui-root` header. The result is that the tapbar themes no longer move the main nav to the bottom.

## Verification

Tested on Home Assistant 2026.8.2 with a mobile viewport and desktop viewport:

- `minimalist-mobile-tapbar`
  - mobile: header/nav is fixed at the bottom
  - mobile: bottom nav can scroll horizontally
  - desktop: compatibility style does not inject, so it does not cover the sidebar/profile icon

- `minimalist-ios-tapbar`
  - mobile: header/nav is fixed at the bottom
  - mobile: bottom nav can scroll horizontally
  - desktop: compatibility style does not inject, so it does not cover the sidebar/profile icon

No personal configuration, entity IDs, tokens, URLs, or Home Assistant instance details are included.
